### PR TITLE
Add loss per token to forward pass

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -33,7 +33,7 @@ import transformer_lens.loading_from_pretrained as loading
 import transformer_lens.utils as utils
 
 SingleLoss = TT[()] # Type alias for a single element tensor
-LossPerToken = TT[("batch", "pos")]
+LossPerToken = TT["batch", "pos"]
 Loss = Union[SingleLoss, LossPerToken]
 
 # Named tuple object for if we want to output both logits and loss

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -152,6 +152,7 @@ class HookedTransformer(HookedRootModule):
         self, 
         input, 
         return_type: Literal["logits"], 
+        loss_per_token: bool = False,
         prepend_bos: bool = True,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None) -> Loss:
         ...
@@ -161,6 +162,7 @@ class HookedTransformer(HookedRootModule):
         self, 
         input, 
         return_type: Literal["loss"], 
+        loss_per_token: bool = False,
         prepend_bos: bool = True,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None) -> Loss:
         ...
@@ -170,6 +172,7 @@ class HookedTransformer(HookedRootModule):
         self, 
         input, 
         return_type: Literal["both"], 
+        loss_per_token: bool = False,
         prepend_bos: bool = True,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None) -> Tuple[TT["batch", "pos", "d_vocab"], Loss]:
         ...
@@ -179,6 +182,7 @@ class HookedTransformer(HookedRootModule):
         self, 
         input, 
         return_type: Literal[None], 
+        loss_per_token: bool = False,
         prepend_bos: bool = True,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None) -> None:
         ...


### PR DESCRIPTION
This PR allows forward calls to `HookedTransformer`s to give the loss at each token. `per_token` is already a flag for the loss function so this is easy. This is the second time I've wanted this in the forward pass, so thought I'd propose a PR.