### PR TITLE
add hook tokens

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -106,6 +106,9 @@ class HookedTransformer(HookedRootModule):
             self.pos_embed = PosEmbed(self.cfg)
             self.hook_pos_embed = HookPoint()  # [batch, pos, d__dictmodel]
 
+        if self.cfg.hook_tokens:
+            self.hook_tokens = HookPoint() # [batch, pos]
+
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(self.cfg, block_index)
@@ -254,6 +257,8 @@ class HookedTransformer(HookedRootModule):
                 cache_ctx_length == 0 or ctx_length == 1
             ), "Pass in one token at a time after loading cache"
             pos_offset = cache_ctx_length
+        if self.cfg.hook_tokens:
+            tokens = self.hook_tokens(tokens)
         embed = self.hook_embed(self.embed(tokens))  # [batch, pos, d_model]
         if self.cfg.positional_embedding_type == "standard":
             pos_embed = self.hook_pos_embed(

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -106,7 +106,7 @@ class HookedTransformer(HookedRootModule):
             self.pos_embed = PosEmbed(self.cfg)
             self.hook_pos_embed = HookPoint()  # [batch, pos, d__dictmodel]
 
-        if self.cfg.hook_tokens:
+        if self.cfg.use_hook_tokens:
             self.hook_tokens = HookPoint() # [batch, pos]
 
         self.blocks = nn.ModuleList(
@@ -257,7 +257,7 @@ class HookedTransformer(HookedRootModule):
                 cache_ctx_length == 0 or ctx_length == 1
             ), "Pass in one token at a time after loading cache"
             pos_offset = cache_ctx_length
-        if self.cfg.hook_tokens:
+        if self.cfg.use_hook_tokens:
             tokens = self.hook_tokens(tokens)
         embed = self.hook_embed(self.embed(tokens))  # [batch, pos, d_model]
         if self.cfg.positional_embedding_type == "standard":

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -116,6 +116,8 @@ class HookedTransformerConfig:
             the [scaling laws paper](https://arxiv.org/pdf/2001.08361.pdf) found
             that that was a more meaningful number. Ignoring biases and layer
             norms, for convenience)
+        hook_tokens (bool): If true, will add a hook at tokens (useful for implementing
+            BERT-style masking of padding tokens via permanent hooks). Defaults to False.
     """
 
     n_layers: int
@@ -154,6 +156,7 @@ class HookedTransformerConfig:
     parallel_attn_mlp: bool = False
     rotary_dim: Optional[int] = None
     n_params: Optional[int] = None
+    hook_tokens: bool = False
 
     def __post_init__(self):
         if self.n_heads==-1:

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -116,8 +116,9 @@ class HookedTransformerConfig:
             the [scaling laws paper](https://arxiv.org/pdf/2001.08361.pdf) found
             that that was a more meaningful number. Ignoring biases and layer
             norms, for convenience)
-        hook_tokens (bool): If true, will add a hook at tokens (useful for implementing
-            BERT-style masking of padding tokens via permanent hooks). Defaults to False.
+        use_hook_tokens (bool): Will add a hook point on the token input to 
+            HookedTransformer.forward, which lets you cache or intervene on the tokens.
+            Defaults to False.
     """
 
     n_layers: int
@@ -156,7 +157,7 @@ class HookedTransformerConfig:
     parallel_attn_mlp: bool = False
     rotary_dim: Optional[int] = None
     n_params: Optional[int] = None
-    hook_tokens: bool = False
+    use_hook_tokens: bool = False
 
     def __post_init__(self):
         if self.n_heads==-1:

--- a/transformer_lens/tests/test_hook_tokens.py
+++ b/transformer_lens/tests/test_hook_tokens.py
@@ -1,0 +1,54 @@
+# %%
+
+from typeguard.importhook import install_import_hook
+
+install_import_hook("transformer_lens")
+
+from transformer_lens import HookedTransformer, HookedTransformerConfig
+from torchtyping import TensorType as TT, patch_typeguard
+from transformer_lens.hook_points import HookPoint
+
+import functools
+import torch as t
+
+patch_typeguard()
+
+def test_patch_tokens():
+
+    # Define small transformer
+    cfg = HookedTransformerConfig(
+        n_layers=1, 
+        d_mlp=10, 
+        d_model=10, 
+        d_head=5, 
+        n_heads=2, 
+        n_ctx=20, 
+        act_fn="relu",
+        tokenizer_name="gpt2",
+        use_hook_tokens=True
+    )
+    model = HookedTransformer(cfg=cfg)
+
+    # Define short prompt, and a token to replace the first token with (note this is index 1, because BOS)
+    prompt = "Hello World!"
+    modified_prompt = "Hi World!"
+    new_first_token = model.to_single_token("Hi")
+
+    # Define hook function to alter the first token
+    def hook_fn(tokens: TT["batch", "seq"], hook: HookPoint, new_first_token: int):
+        assert tokens[0, 0].item() != new_first_token # Need new_first_token to be different from original
+        tokens[0, 0] = new_first_token
+        return tokens
+    
+    # Run with hooks
+    out_from_hook = model.run_with_hooks(
+        prompt,
+        prepend_bos=False,
+        fwd_hooks = [
+            ("hook_tokens", functools.partial(hook_fn, new_first_token=new_first_token))
+        ]
+    )
+
+    out_direct = model(modified_prompt, prepend_bos=False)
+
+    t.testing.assert_close(out_from_hook, out_direct)


### PR DESCRIPTION
Added `hook_tokens` option to the config object (default value is `False`). If this is true, then we call:

```python
tokens = self.hook_tokens(tokens)
```

before applying the embedding, in our HookedTransformer's forward pass.

---

The files that were edited were:

* `HookedTransformerConfig` (to add `hook_tokens` as a default argument, and add a docstring to the config object)
* `HookedTransformer` (in 2 places - once to define the hooks, and once to apply them if they exist)

---

This is useful when we combine it with permanent hooks to e.g. implement certain types of model architecture. Here is an example of how we can use this feature to turn a bidirectional transformer into one which applies a mask to the padding tokens at each attention layer, in the style of BERT:

```python
def add_perma_hooks_to_mask_pad_tokens(model: HookedTransformer, pad_token: int) -> model:

    # Hook which operates on the tokens, and stores a mask where tokens equal [pad]
    def cache_padding_tokens_mask(
        tokens: TT["batch", "seq"],
        hook: HookPoint,
    ) -> None:
        hook.ctx["padding_tokens_mask"] = einops.rearrange(tokens == pad_token, "b sK -> b 1 1 sK")

    # Apply masking, by referencing the mask stored in the `hook_tokens` hook context
    # If this attention layer is the last one, then clear the information from the `hook_tokens` context
    def apply_padding_tokens_mask(
        attn_scores: TT["batch", "head", "seq_Q", "seq_K"],
        hook: HookPoint,
    ) -> None:
        attn_scores.masked_fill_(model.hook_dict["hook_tokens"].ctx["padding_tokens_mask"], -1e5)
        if hook.layer() == model.cfg.n_layers - 1:
            del model.hook_dict["hook_tokens"].ctx["padding_tokens_mask"]

    # Add these hooks as permanent hooks (i.e. they aren't removed after functions like run_with_hooks)
    for name, hook in model.hook_dict.items():
        if name == "hook_tokens":
            hook.add_perma_hook(cache_padding_tokens_mask)
        elif name.endswith("attn_scores"):
            hook.add_perma_hook(apply_padding_tokens_mask)

    return model

if MAIN:
    cfg = HookedTransformerConfig(
        hook_tokens = True,
        ...
    )
    model = HookedTransformer(cfg)
    model = add_perma_hooks_to_mask_pad_tokens(model, tokenizer.PAD_TOKEN)
```