### PR TITLE
Fix OPT BOS Prepending issue

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -407,7 +407,7 @@ class HookedTransformer(HookedRootModule):
             padding = True,
             truncation = truncate,
             max_length = self.cfg.n_ctx if truncate else None,
-            add_special_tokens=False  # As we manually add the BOS token
+            add_special_tokens = False  # As we manually add the BOS token
             )["input_ids"]
         if move_to_device:
             tokens = tokens.to(self.cfg.device)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -406,7 +406,8 @@ class HookedTransformer(HookedRootModule):
             return_tensors = "pt", 
             padding = True,
             truncation = truncate,
-            max_length = self.cfg.n_ctx if truncate else None
+            max_length = self.cfg.n_ctx if truncate else None,
+            add_special_tokens=False  # As we manually add the BOS token
             )["input_ids"]
         if move_to_device:
             tokens = tokens.to(self.cfg.device)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -407,7 +407,7 @@ class HookedTransformer(HookedRootModule):
             padding = True,
             truncation = truncate,
             max_length = self.cfg.n_ctx if truncate else None,
-            add_special_tokens = False  # As we manually add the BOS token
+            add_special_tokens = False if self.tokenizer.name_or_path.startswith('facebook/opt') else True  # As we manually add the BOS token
             )["input_ids"]
         if move_to_device:
             tokens = tokens.to(self.cfg.device)

--- a/transformer_lens/tests/test_tokenizer_special_tokens.py
+++ b/transformer_lens/tests/test_tokenizer_special_tokens.py
@@ -10,7 +10,7 @@ import transformer_lens.loading_from_pretrained as loading
 patch_typeguard()
 
 # Get's tedious typing these out everytime I want to sweep over all the distinct small models
-MODEL_TESTING_LIST = ['gpt2-small', 'gpt-neo-125M', 'opt-125m', 'opt-30b', 'stanford-gpt2-small-a', 'pythia-19m']
+MODEL_TESTING_LIST = ['solu-1l', 'gpt2-small', 'gpt-neo-125M', 'opt-125m', 'opt-30b', 'stanford-gpt2-small-a', 'pythia-19m']
 def test_d_vocab_from_tokenizer():
     cfg = HookedTransformerConfig(
         n_layers=1,
@@ -24,7 +24,10 @@ def test_d_vocab_from_tokenizer():
     test_string = 'a fish.'
     # Test tokenizers for different models
     for model_name in MODEL_TESTING_LIST:
-        tokenizer_name = loading.get_official_model_name(model_name)
+        if model_name == 'solu-1l':
+            tokenizer_name = 'NeelNanda/gpt-neox-tokenizer-digits'
+        else:
+            tokenizer_name = loading.get_official_model_name(model_name)
         
         model = HookedTransformer(
             cfg=cfg,

--- a/transformer_lens/tests/test_tokenizer_special_tokens.py
+++ b/transformer_lens/tests/test_tokenizer_special_tokens.py
@@ -1,0 +1,48 @@
+from typeguard.importhook import install_import_hook
+
+install_import_hook("transformer_lens")
+
+from transformer_lens import HookedTransformer, HookedTransformerConfig
+from torchtyping import TensorType as TT, patch_typeguard
+from transformers import AutoTokenizer
+import transformer_lens.loading_from_pretrained as loading
+
+patch_typeguard()
+
+# Get's tedious typing these out everytime I want to sweep over all the distinct small models
+MODEL_TESTING_LIST = ['gpt2-small', 'gpt-neo-125M', 'opt-125m', 'opt-30b', 'stanford-gpt2-small-a', 'pythia-19m']
+def test_d_vocab_from_tokenizer():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_mlp=10,
+        d_model=10,
+        d_head=5,
+        n_heads=2,
+        n_ctx=20,
+        act_fn="relu"
+    )
+    test_string = 'a fish.'
+    # Test tokenizers for different models
+    for model_name in MODEL_TESTING_LIST:
+        tokenizer_name = loading.get_official_model_name(model_name)
+        
+        model = HookedTransformer(
+            cfg=cfg,
+            tokenizer=AutoTokenizer.from_pretrained(tokenizer_name)
+        )
+        # Jank token setup
+        # Perhaps we should write a wrapper around the tokenizer
+        if model.tokenizer.eos_token is None:
+            model.tokenizer.eos_token = "<|endoftext|>"
+        if model.tokenizer.pad_token is None:
+            model.tokenizer.pad_token = model.tokenizer.eos_token
+        if model.tokenizer.bos_token is None:
+            model.tokenizer.bos_token = model.tokenizer.eos_token
+
+        tokens_with_bos = model.to_tokens(test_string)
+        tokens_without_bos = model.to_tokens(test_string, prepend_bos=False)
+        
+        # Check that the lengths are different by one
+        assert tokens_with_bos.shape[-1] == tokens_without_bos.shape[-1] + 1, 'BOS Token not added when expected'
+        # Check that we don't have BOS when we disable the flag
+        assert tokens_without_bos.squeeze()[0] != model.tokenizer.bos_token_id, "BOS token is present when it shouldn't be"


### PR DESCRIPTION
This addresses issue https://github.com/neelnanda-io/TransformerLens/issues/153.

For reasons that are unclear to me, the PreTrainedtokenizer for Facebook OPT automatically prepends `</s>` to OPT prompts, unless the tokenizer call sets `add_special_tokens=False`. This has no effect for the GPT tokenizer.

*I Am not sure* if this breaks things for other models, in which case we'd want to do `add_special_tokens='opt' in self.tokenizer.name` but would prefer to avoid that if possible.