### PR TITLE
Silence DeprecationWarning for distutils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,10 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.extras]
 docs = ["Sphinx", "sphinx-autobuild", "sphinxcontrib-napoleon", "furo", "myst_parser","tabulate"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # Ignore numpy.distutils deprecation warning caused by pandas
+    # More info: https://numpy.org/doc/stable/reference/distutils.html#module-numpy.distutils
+    "ignore:distutils Version classes are deprecated:DeprecationWarning"
+]


### PR DESCRIPTION
Silence warnings in test output. 

I think these warnings are caused because pandas is using `LooseVersion` from `numpy.distutils`, which is [deprecated](https://numpy.org/doc/stable/reference/distutils.html).

## Output before change
```python
❯ poetry run pytest transformer_lens/tests
================================== test session starts ===================================
platform darwin -- Python 3.9.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/rusheb/code/TransformerLens
plugins: jaxtyping-0.2.12, typeguard-2.13.3, cov-4.0.0, anyio-3.6.2
collected 29 items

transformer_lens/tests/test_cache_hook_names.py .                                  [  3%]
transformer_lens/tests/test_d_vocab.py ....                                        [ 17%]
transformer_lens/tests/test_hook_tokens.py .                                       [ 20%]
transformer_lens/tests/test_hooks.py ....                                          [ 34%]
transformer_lens/tests/test_stop_at_layer.py .......                               [ 58%]
transformer_lens/tests/test_tokenizer_special_tokens.py .                          [ 62%]
transformer_lens/tests/test_transformer_lens.py ...........                        [100%]

==================================== warnings summary ====================================
.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:10
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:10: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _nlv = LooseVersion(_np_version)

.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:11
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:11: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p16 = _nlv < LooseVersion("1.16")

.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:12
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:12: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p17 = _nlv < LooseVersion("1.17")

.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:13
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:13: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p18 = _nlv < LooseVersion("1.18")

.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:14
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:14: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p19 = _nlv < LooseVersion("1.19")

.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:15
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:15: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p20 = _nlv < LooseVersion("1.20")

.venv/lib/python3.9/site-packages/setuptools/_distutils/version.py:345
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/setuptools/_distutils/version.py:345: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    other = LooseVersion(other)

.venv/lib/python3.9/site-packages/pandas/compat/numpy/function.py:125
.venv/lib/python3.9/site-packages/pandas/compat/numpy/function.py:125
  /Users/rusheb/code/TransformerLens/.venv/lib/python3.9/site-packages/pandas/compat/numpy/function.py:125: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(_np_version) >= LooseVersion("1.17.0"):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 29 passed, 9 warnings in 107.19s (0:01:47) =======================
```


## Output after change

```python
❯ poetry run pytest transformer_lens/tests
===================================================== test session starts =====================================================
platform darwin -- Python 3.9.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/rusheb/code/TransformerLens, configfile: pyproject.toml
plugins: jaxtyping-0.2.12, typeguard-2.13.3, cov-4.0.0, anyio-3.6.2
collected 29 items

transformer_lens/tests/test_cache_hook_names.py .                                  [  3%]
transformer_lens/tests/test_d_vocab.py ....                                        [ 17%]
transformer_lens/tests/test_hook_tokens.py .                                       [ 20%]
transformer_lens/tests/test_hooks.py ....                                          [ 34%]
transformer_lens/tests/test_stop_at_layer.py .......                               [ 58%]
transformer_lens/tests/test_tokenizer_special_tokens.py .                          [ 62%]
transformer_lens/tests/test_transformer_lens.py ...........                        [100%]

=============================================== 29 passed in 100.57s (0:01:40) ================================================
