### PR TITLE
Configure coverage reports to measure branch coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,9 +56,9 @@ jobs:
           poetry lock --check
           poetry install --with dev
       - name: Unit test
-        run: poetry run pytest -v --cov=transformer_lens/ --cov-report=term-missing tests/unit
+        run: poetry run pytest -v --cov=transformer_lens/ --cov-report=term-missing --cov-branch tests/unit
       - name: Acceptance test
-        run: poetry run pytest -v --cov=transformer_lens/ --cov-report=term-missing tests/acceptance
+        run: poetry run pytest -v --cov=transformer_lens/ --cov-report=term-missing --cov-branch tests/acceptance
       # - name: Type check
       #   run: poetry run mypy transformer_lens
       - name: Build check

--- a/tests/acceptance/test_transformer_lens.py
+++ b/tests/acceptance/test_transformer_lens.py
@@ -47,6 +47,7 @@ def test_model(name, expected_loss):
     model = HookedTransformer.from_pretrained(name)
     loss = model(text, return_type="loss")
     assert (loss.item() - expected_loss) < 4e-5
+    pass
 
 
 def test_from_pretrained_no_processing():

--- a/tests/acceptance/test_transformer_lens.py
+++ b/tests/acceptance/test_transformer_lens.py
@@ -47,7 +47,6 @@ def test_model(name, expected_loss):
     model = HookedTransformer.from_pretrained(name)
     loss = model(text, return_type="loss")
     assert (loss.item() - expected_loss) < 4e-5
-    pass
 
 
 def test_from_pretrained_no_processing():


### PR DESCRIPTION
Add [branch coverage](https://coverage.readthedocs.io/en/7.1.0/branch.html). Closes #189.

Note: I had to add a dummy commit and revert it to trigger github actions, in order to ensure that the reports are being printed correctly.

At a glance, this produces the following changes in the report:
* New columns: `Branch` and `BrPart`
* Modified percentages in `Cover` column
* `Missing` column seems to have been modified to reflect branches rather than lines 

One thing that is unclear to me from the report is how the coverage percentage is actually computed. It looks like we could get more information on branch coverage by using the html, xml or json report types, but this would take more effort to set up. [Quote from cov docs](https://coverage.readthedocs.io/en/7.1.0/branch.html#how-to-measure-branch-coverage):
> The HTML report gives information about which lines had missing branches. Lines that were missing some branches are shown in yellow, with an annotation at the far right showing branch destination line numbers that were not exercised.
>
> The XML and JSON reports produced by coverage xml and coverage json also include branch information, including separate statement and branch coverage percentages.


## Output [before](https://github.com/neelnanda-io/TransformerLens/actions/runs/4379785881/jobs/7666113168):
```python
 ---------- coverage: platform linux, python 3.10.10-final-0 ----------
Name                                          Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------
transformer_lens/ActivationCache.py             248    191    23%   47-55, 61, 71-77, 81, 89-94, 106, 113, 116, 119, 125-131, 160-181, 215-247, 255-262, 285-328, 347-353, 373-387, 410-454, 488-506, 529-581
transformer_lens/FactoredMatrix.py              101     44    56%   14-27, 33-46, 52-63, 74, 96-102, 124-132, 147, 159
transformer_lens/HookedTransformer.py           546    205    62%   72, 74, 84, 88, 110, 121, 127, 130-134, 239, 241, 252-266, 268, 276-288, 323-329, 385-387, 415, 436-450, 475-495, 504-507, 531-556, 574-589, 598-600, 604-607, 612, 616, 745, 784, 792, 796, 806, 828, 830, 1045-1090, 1117-1127, 1180-1264, 1378, 1382, 1397-1407, 1419-1437, 1441, 1461-1477, 1488-1493
transformer_lens/HookedTransformerConfig.py      87     12    86%   167-170, 175, 177-180, 186, 203, 225, 228, 231-232
transformer_lens/__init__.py                     15      0   100%
transformer_lens/components.py                  314     83    74%   28, 46, 72, 106, 137, 143, 167-174, 180, 196-209, 215-218, 241, 267-274, 284, 286, 299, 302-307, 336, 387-388, 394, 490-491, 503-512, 523-530, 538-542, 556, 569, 571, 573, 575, 581, 616, 627-632, 639-641, 687, 711-722
transformer_lens/evals.py                        69     49    29%   21-23, 33-39, 48-54, 63-69, 76-84, 98-106, 120-134, 140-148
transformer_lens/hook_points.py                 151     24    84%   53-59, 92, 187-193, 198, 231, 233, 239, 244-247, 253, 284, 291-294, 311
transformer_lens/loading_from_pretrained.py     347    266    23%   326, 340-434, 466, 472, 510, 518, 523-524, 527-538, 552-553, 573-590, 616, 623, 626-652, 666-681, 688-739, 744-786, 791-832, 837-901, 906-991, 1011-1028
transformer_lens/make_docs.py                    41     41     0%   2-63
transformer_lens/past_key_value_caching.py       27      4    85%   35-42
transformer_lens/patching.py                    119     70    41%   38-41, 87-148, 164-167, 179-182, 194-198, 210-214, 226-230, 242-246, 350-355, 361-369, 375-378
transformer_lens/train.py                        73     42    42%   70-148
transformer_lens/utils.py                       228    132    42%   43-44, 47, 54-57, 69-72, 87-95, 109-112, 153-155, 185-230, 265-301, 374-375, 453-499, 507-508, 529-561, 582-597, 618-632
---------------------------------------------------------------------------
TOTAL                                          2366   1163    51%
```

## Output [after](https://github.com/neelnanda-io/TransformerLens/actions/runs/4384143279/jobs/7675253304):
```python
 ---------- coverage: platform linux, python 3.10.10-final-0 ----------
Name                                          Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------------
transformer_lens/ActivationCache.py             248    191    134      1    15%   47-55, 61, 71-77, 81, 89-94, 106, 113, 116, 119, 125-131, 160-181, 215-247, 255-262, 285-328, 347-353, 373-387, 410-454, 488-506, 529-581
transformer_lens/FactoredMatrix.py              101     44     26      0    45%   14-27, 33-46, 52-63, 74, 96-102, 124-132, 147, 159
transformer_lens/HookedTransformer.py           546    205    256     65    53%   72, 74, 84, 88, 105->109, 110, 121, 127, 130-134, 142->147, 239, 241, 252-266, 268, 276-288, 314->316, 323-329, 372->378, 385-387, 411->416, 415, 424->426, 436-450, 475-495, 504-507, 531-556, 574-589, 598-600, 604-607, 612, 616, 745, 779->781, 782->790, 784, 790->801, 792, 796, 801->803, 803->805, 806, 828, 830, 899->844, 922->844, 947->953, 971->975, 985->975, 1045-1090, 1117-1127, 1180-1264, 1308->exit, 1308->exit, 1314->exit, 1314->exit, 1320->exit, 1320->exit, 1326->exit, 1326->exit, 1332->exit, 1332->exit, 1338->exit, 1338->exit, 1344->exit, 1344->exit, 1350->exit, 1350->exit, 1356->exit, 1356->exit, 1362->exit, 1362->exit, 1368->exit, 1368->exit, 1374->exit, 1374->exit, 1378, 1382, 1397-1407, 1419-1437, 1441, 1461-1477, 1488-1493
transformer_lens/HookedTransformerConfig.py      87     12     24     10    78%   13->15, 167-170, 175, 177-180, 183->193, 186, 193->197, 203, 209->213, 213->exit, 225, 228, 231-232
transformer_lens/__init__.py                     15      0      0      0   100%
transformer_lens/components.py                  314     83     92     31    67%   28, 46, 72, 106, 137, 143, 167-174, 180, 196-209, 215-218, 241, 267-274, 284, 286, 299, 302-307, 336, 387-388, 394, 406->411, 490-491, 503-512, 523-530, 538-542, 556, 569, 571, 573, 575, 576->586, 581, 616, 620->636, 625->636, 627-632, 639-641, 642->645, 652->654, 687, 711-722
transformer_lens/evals.py                        69     49     12      0    25%   21-23, 33-39, 48-54, 63-69, 76-84, 98-106, 120-134, 140-148
transformer_lens/hook_points.py                 151     24     84     16    76%   12->14, 53-59, 74->76, 76->78, 78->79, 92, 187-193, 196->exit, 198, 223->225, 225->228, 231, 233, 239, 244-247, 253, 284, 286->288, 291-294, 311
transformer_lens/loading_from_pretrained.py     347    266    112     11    22%   326, 340-434, 466, 472, 510, 518, 519->526, 523-524, 527-538, 552-553, 573-590, 616, 623, 626-652, 666-681, 688-739, 744-786, 791-832, 837-901, 906-991, 1011-1028
transformer_lens/make_docs.py                    41     41     28      0     0%   2-63
transformer_lens/past_key_value_caching.py       27      4      6      4    76%   9->11, 35-42, 46->48, 63->exit, 63->exit
transformer_lens/patching.py                    119     70     14      0    37%   38-41, 87-148, 164-167, 179-182, 194-198, 210-214, 226-230, 242-246, 350-355, 361-369, 375-378
transformer_lens/train.py                        73     42     34      1    30%   14->16, 70-148
transformer_lens/utils.py                       228    132     96      4    36%   43-44, 47, 54-57, 69-72, 87-95, 109-112, 153-155, 185-230, 265-301, 374-375, 379->383, 453-499, 507-508, 529-561, 582-597, 618-632
-----------------------------------------------------------------------------------------
TOTAL                                          2366   1163    918    143    44%

======================= 33 passed, 9 warnings in 16.81s ========================
```
