### PR TITLE
Fix test command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If adding a feature, please add unit tests for it to the tests folder, and check
 To run tests, you can use the following command:
 
 ```
-poetry run pytest -v transformer_lens/tests
+poetry run pytest -v tests
 ```
 
 ## Citation


### PR DESCRIPTION
Since #191 the tests live in a top level `/tests` folder.