### PR TITLE
Add context manager

### DIFF
--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -17,12 +17,14 @@ class Counter:
     def inc(self, *args, **kwargs):
         self.count += 1
 
+
 def test_hook_attaches_normally():
     c = Counter()
     _ = model.run_with_hooks(prompt, fwd_hooks=[(embed, c.inc)])
     assert all([len(hp.fwd_hooks) == 0 for _, hp in model.hook_dict.items()])
     assert c.count == 1
     model.remove_all_hook_fns(including_permanent=True)
+
 
 def test_perma_hook_attaches_normally():
     c = Counter()
@@ -32,6 +34,72 @@ def test_perma_hook_attaches_normally():
     assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
     assert c.count == 1
     model.remove_all_hook_fns(including_permanent=True)
+
+
+def test_hook_context_manager():
+    c = Counter()
+    with model.hooks(fwd_hooks=[(embed, c.inc)]):
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+        model.forward(prompt)
+    assert len(model.hook_dict['hook_embed'].fwd_hooks) == 0
+    assert c.count == 1
+    model.remove_all_hook_fns(including_permanent=True)
+
+
+def test_nested_hook_context_manager():
+    c = Counter()
+    with model.hooks(fwd_hooks=[(embed, c.inc)]):
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+        model.forward(prompt)
+        assert c.count == 1
+        with model.hooks(fwd_hooks=[(embed, c.inc)]):
+            assert len(model.hook_dict['hook_embed'].fwd_hooks) == 2
+            model.forward(prompt)
+            assert c.count == 3  # 2 from outer, 1 from inner
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+    assert len(model.hook_dict['hook_embed'].fwd_hooks) == 0
+    assert c.count == 3
+    model.remove_all_hook_fns(including_permanent=True)
+
+
+def test_hook_context_manager_with_permanent_hook():
+    c = Counter()
+    model.add_perma_hook(embed, c.inc)
+    assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+    with model.hooks(fwd_hooks=[(embed, c.inc)]):
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 2
+        model.forward(prompt)
+    assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+    assert c.count == 2  # 1 from permanent, 1 from context manager
+    model.remove_all_hook_fns(including_permanent=True)
+
+
+def test_nested_context_manager_with_failure():
+
+    def fail_hook(z, hook):
+        raise ValueError("fail")
+    
+    c = Counter()
+    with model.hooks(fwd_hooks=[(embed, c.inc)]):
+        with pytest.raises(ValueError):
+            with model.hooks(fwd_hooks=[(embed, fail_hook)]):
+                assert len(model.hook_dict['hook_embed'].fwd_hooks) == 2
+                model.forward(prompt)
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+        assert c.count == 1
+    assert len(model.hook_dict['hook_embed'].fwd_hooks) == 0
+    model.remove_all_hook_fns(including_permanent=True)
+
+
+def test_reset_hooks_in_context_manager():
+    c = Counter()
+    with model.hooks(fwd_hooks=[(embed, c.inc)]):
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+        model.reset_hooks()
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 0
+    assert len(model.hook_dict['hook_embed'].fwd_hooks) == 0
+    model.remove_all_hook_fns(including_permanent=True)
+
 
 def test_remove_hook():
     c = Counter()
@@ -44,6 +112,7 @@ def test_remove_hook():
     model.run_with_hooks(prompt, fwd_hooks=[])
     assert c.count == 0
     model.remove_all_hook_fns(including_permanent=True)
+
 
 def test_conditional_hooks():
     """Test that it's only possible to add certain hooks when certain conditions are met"""

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -62,6 +62,17 @@ def test_nested_hook_context_manager():
     model.remove_all_hook_fns(including_permanent=True)
 
 
+def test_context_manager_run_with_cache():
+    c = Counter()
+    with model.hooks(fwd_hooks=[(embed, c.inc)]):
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+        model.run_with_cache(prompt)
+        assert len(model.hook_dict['hook_embed'].fwd_hooks) == 1
+    assert len(model.hook_dict['hook_embed'].fwd_hooks) == 0
+    assert c.count == 1
+    model.remove_all_hook_fns(including_permanent=True)
+
+
 def test_hook_context_manager_with_permanent_hook():
     c = Counter()
     model.add_perma_hook(embed, c.inc)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -150,12 +150,11 @@ class HookedTransformer(HookedRootModule):
         # Needed for HookPoints to work
         self.setup()
 
-    def check_and_add_hook(self, hook_point, hook_point_name, hook, dir="fwd", is_permanent=False) -> None:
+    def check_hooks_to_add(self, hook_point, hook_point_name, hook, dir="fwd", is_permanent=False) -> None:
         if hook_point_name.endswith("attn.hook_result"):
             assert self.cfg.use_attn_result, f"Cannot add hook {hook_point_name} if use_attn_result_hook is False"
         if hook_point_name.endswith(("hook_q_input", "hook_k_input", "hook_v_input")):
             assert self.cfg.use_split_qkv_input, f"Cannot add hook {hook_point_name} if use_split_qkv_input is False"
-        hook_point.add_hook(hook, dir=dir, is_permanent=is_permanent)
 
     @overload
     def forward(


### PR DESCRIPTION
This would let you run the model like this:
```python
with model.hooks(fwd_hooks=hooks):
    hooked_loss = model(text, return_type="loss")
```

A quick example:
```python
from transformer_lens.evals import sanity_check, induction_loss
from transformer_lens.HookedTransformer import HookedTransformer
import transformer_lens.utils as utils

model = HookedTransformer.from_pretrained('gpt2-small')
text = "The quick brown fox jumps over the lazy dog"
def head_ablation_hook(value, hook):
    value[:, :, 8, :] = 0.
    return value
hooks = [(utils.get_act_name("v", 0), head_ablation_hook)]


###### This allows us to do: ######
print("Normal induction loss", induction_loss(model))
with model.hooks(fwd_hooks=hooks):
    print('Hooked induction loss', induction_loss(model))


###### Making sure we can still do basic stuff ######
normal_loss = model(text, return_type="loss")
print(f"Normal loss: {normal_loss}")

ablated_loss = model.run_with_hooks(
    text, 
    return_type="loss", 
    fwd_hooks=hooks,
    )
print(f"Ablated loss: {ablated_loss}")

with model.hooks(fwd_hooks=hooks):
    hooked_loss = model(text, return_type="loss")
print(f"Hooked loss: {hooked_loss}")

normal_loss = model(text, return_type="loss")
print(f"Normal loss: {normal_loss}")

```