### PR TITLE
set specific poetry version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.4.0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
# Description

GH-Pages workflow is broken due to Poetry release last line (https://pypi.org/project/poetry/#history) 

This should fix the issue by going back to the previous version. Only setting it for gh-pages as regular workflow seems fine. Hopefully this is just a temporary measure. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

<img width="700" alt="Screenshot 2023-03-21 at 7 14 09 am" src="https://user-images.githubusercontent.com/69127271/226455058-5f0f711d-ae85-4699-a983-b02b01584f21.png">
