### PR TITLE
Remove torchtyping from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         "datasets",
         "wandb",
         "fancy_einsum",
-        "torchtyping",
         "rich",
     ],
     extras_require={"dev": ["pytest", "mypy", "pytest-cov"]},


### PR DESCRIPTION
# Description


Remove `torchtyping` from `install_requires` in `setup.py`.

I'm not sure, but I think this is no longer needed. As far as I can see, this dependency was removed from `pyproject.toml` in 30ed77338f54b765a80d7e12d8fa24b5281c3145 (PR #171).

No issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
