### PR TITLE
Add apply_ln param to accumulated_resid and decompose_resid

### DIFF
--- a/tests/acceptance/test_activation_cache.py
+++ b/tests/acceptance/test_activation_cache.py
@@ -123,3 +123,43 @@ def test_logit_attrs_works_for_all_input_shapes():
     batch = [2,5,7]
     logit_diffs = cache.logit_attrs(accumulated_residual, batch_slice=batch, pos_slice=-1, tokens=answer_tokens[batch,0], incorrect_tokens=answer_tokens[batch,1])
     assert torch.isclose(ref_logit_diffs[:,batch],logit_diffs).all()
+
+@torch.set_grad_enabled(False)
+def test_accumulated_resid_apply_ln():
+
+    # Load solu-2l
+    model = load_model('solu-2l')
+
+    tokens, _ = get_ioi_tokens_and_answer_tokens(model)
+
+    # Run the model and cache all activations
+    _, cache = model.run_with_cache(tokens)
+
+    # Get accumulated resid and apply ln seperately (cribbed notebook code)
+    accumulated_residual = cache.accumulated_resid(layer=-1, incl_mid=True, pos_slice=-1)
+    ref_scaled_residual_stack = cache.apply_ln_to_stack(accumulated_residual, layer=-1, pos_slice=-1)
+    
+    # Get scaled_residual_stack using apply_ln parameter
+    scaled_residual_stack = cache.accumulated_resid(layer=-1, incl_mid=True, pos_slice=-1, apply_ln=True)
+
+    assert torch.isclose(ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7).all()
+
+@torch.set_grad_enabled(False)
+def test_decompose_resid_apply_ln():
+
+    # Load solu-2l
+    model = load_model('solu-2l')
+
+    tokens, _ = get_ioi_tokens_and_answer_tokens(model)
+
+    # Run the model and cache all activations
+    _, cache = model.run_with_cache(tokens)
+
+    # Get decomposed resid and apply ln seperately (cribbed notebook code)
+    per_layer_residual = cache.decompose_resid(layer=-1, pos_slice=-1)
+    ref_scaled_residual_stack = cache.apply_ln_to_stack(per_layer_residual, layer=-1, pos_slice=-1)
+    
+    # Get scaled_residual_stack using apply_ln parameter
+    scaled_residual_stack = cache.decompose_resid(layer=-1, pos_slice=-1, apply_ln=True)
+
+    assert torch.isclose(ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7).all()

--- a/tests/acceptance/test_activation_cache.py
+++ b/tests/acceptance/test_activation_cache.py
@@ -125,7 +125,7 @@ def test_logit_attrs_works_for_all_input_shapes():
     assert torch.isclose(ref_logit_diffs[:,batch],logit_diffs).all()
 
 @torch.set_grad_enabled(False)
-def test_accumulated_resid_apply_ln():
+def test_accumulated_resid_with_apply_ln():
 
     # Load solu-2l
     model = load_model('solu-2l')
@@ -145,7 +145,7 @@ def test_accumulated_resid_apply_ln():
     assert torch.isclose(ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7).all()
 
 @torch.set_grad_enabled(False)
-def test_decompose_resid_apply_ln():
+def test_decompose_resid_with_apply_ln():
 
     # Load solu-2l
     model = load_model('solu-2l')

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -140,6 +140,7 @@ class ActivationCache:
         self,
         layer: Optional[int] = None,
         incl_mid: bool = False,
+        apply_ln: bool = False,
         pos_slice: Union[Slice, SliceInput] = None,
         mlp_input: bool = False,
         return_labels: bool = False,
@@ -150,6 +151,7 @@ class ActivationCache:
             layer (int, *optional*): The layer to take components up to - by default includes resid_pre for that layer and excludes resid_mid and resid_post for that layer. layer==n_layers, -1 or None means to return all residual streams, including the final one (ie immediately pre logits). The indices are taken such that this gives the accumulated streams up to the input to layer l
             incl_mid (bool, optional): Whether to return resid_mid for all previous layers. Defaults to False.
             mlp_input (bool, optional): Whether to include resid_mid for the current layer - essentially giving MLP input rather than Attn input. Defaults to False.
+            apply_ln (bool, optional): Whether to apply LayerNorm to the stack. Defaults to False.
             pos_slice (Slice): A slice object to apply to the pos dimension. Defaults to None, do nothing.
             return_labels (bool, optional): Whether to return a list of labels for the residual stream components. Useful for labelling graphs. Defaults to True.
 
@@ -177,6 +179,10 @@ class ActivationCache:
                 labels.append(f"{l}_mid")
         components = [pos_slice.apply(c, dim=-2) for c in components]
         components = torch.stack(components, dim=0)
+        if apply_ln:
+            components = self.apply_ln_to_stack(
+                components, layer, pos_slice=pos_slice, mlp_input=mlp_input
+            )
         if return_labels:
             return components, labels
         else:
@@ -246,9 +252,10 @@ class ActivationCache:
         layer: Optional[int] = None,
         mlp_input: bool = False,
         mode: Literal["all", "mlp", "attn"] = "all",
+        apply_ln: bool = False,
         pos_slice: Union[Slice, SliceInput] = None,
         incl_embeds: bool = True,
-        return_labels: bool = False,
+        return_labels: bool= False,
     ) -> Float[torch.Tensor, "layers_covered *batch_and_pos_dims d_model"]:
         """Decomposes the residual stream input to layer L into a stack of the output of previous layers. The sum of these is the input to layer L (plus embedding and pos embedding). This is useful for attributing model behaviour to different components of the residual stream
 
@@ -261,6 +268,7 @@ class ActivationCache:
                 layer - essentially decomposing the residual stream that's input to the MLP input rather than the Attn input. Defaults to False.
             mode (str): Values are "all", "mlp" or "attn". "all" returns all
                 components, "mlp" returns only the MLP components, and "attn" returns only the attention components. Defaults to "all".
+            apply_ln (bool, optional): Whether to apply LayerNorm to the stack. Defaults to False.
             pos_slice (Slice): A slice object to apply to the pos dimension.
                 Defaults to None, do nothing.
             incl_embeds (bool): Whether to include embed & pos_embed
@@ -302,6 +310,10 @@ class ActivationCache:
             labels.append(f"{layer}_attn_out")
         components = [pos_slice.apply(c, dim=-2) for c in components]
         components = torch.stack(components, dim=0)
+        if apply_ln:
+            components = self.apply_ln_to_stack(
+                components, layer, pos_slice=pos_slice, mlp_input=mlp_input
+            )
         if return_labels:
             return components, labels
         else:
@@ -599,7 +611,7 @@ class ActivationCache:
             layer (int): The layer we're inputting into. layer is in [0, n_layers], if layer==n_layers (or None) we're inputting into the unembed (the entire stream), if layer==0 then it's just embed and pos_embed
             mlp_input (bool, optional): Are we inputting to the MLP in that layer or the attn? Must be False for final layer, since that's the unembed. Defaults to False.
             expand_neurons (bool, optional): Whether to expand the MLP outputs to give every neuron's result or just return the MLP layer outputs. Defaults to True.
-            apply_ln (bool, optional): Whether to apply LayerNorm to the stack. Defaults to True.
+            apply_ln (bool, optional): Whether to apply LayerNorm to the stack. Defaults to False.
             pos_slice (Slice, optional): Slice of the positions to take. Defaults to None. See utils.Slice for details.
             return_labels (bool): Whether to return the labels. Defaults to False.
         """

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -255,7 +255,7 @@ class ActivationCache:
         apply_ln: bool = False,
         pos_slice: Union[Slice, SliceInput] = None,
         incl_embeds: bool = True,
-        return_labels: bool= False,
+        return_labels: bool = False,
     ) -> Float[torch.Tensor, "layers_covered *batch_and_pos_dims d_model"]:
         """Decomposes the residual stream input to layer L into a stack of the output of previous layers. The sum of these is the input to layer L (plus embedding and pos embedding). This is useful for attributing model behaviour to different components of the residual stream
 


### PR DESCRIPTION
# Description

This PR addresses #209 making the following changes:
- add optional apply_ln param to accumulated_resid and decompose_resid to automatically apply layernorm to corresponding stack
- adds 2 basic tests to sanity check these both work as intended
- Corrects a typo in get_full_resid_decomposition doc string

## Type of change

- [ x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility