### PR TITLE
Small spelling mistake fix

### DIFF
--- a/docs/source/content/tutorials.md
+++ b/docs/source/content/tutorials.md
@@ -4,4 +4,4 @@
 
 * To see what using it for exploratory analysis in practice looks like, check out [my notebook analysing Indirect Objection Identification](https://neelnanda.io/exploratory-analysis-demo) or [my recording of myself doing research](https://www.youtube.com/watch?v=yo4QvDn-vsU)!
 
-* [What is a Transformer tutotial](https://neelnanda.io/transformer-tutorial)
+* [What is a Transformer tutorial](https://neelnanda.io/transformer-tutorial)


### PR DESCRIPTION
# Description

Noticed a small typo in `tutorials.md` so I changed "tutotial" -> "tutorial"

Fixes # (issue) - no linked issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

![Screenshot 2023-03-29 173343](https://user-images.githubusercontent.com/50868318/228593259-5b57b3e6-f9d9-42e7-91da-05505ea80a6b.png)

# Checklist:

- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

