### PR TITLE
Squeeze 0th dim in vector FactoredMatrix multiply

### DIFF
--- a/tests/unit/factored_matrix/test_multiply_by_vector.py
+++ b/tests/unit/factored_matrix/test_multiply_by_vector.py
@@ -25,18 +25,6 @@ def test_left_matmul_by_vector_leading_dim():
     assert_close(fm @ vector, (a @ b) @ vector)
 
 
-@pytest.mark.skip(
-    """
-    This test fails with
-    AssertionError: The values for attribute 'shape' do not match: torch.Size([1, 4]) != torch.Size([4]).
-
-    I think this is a bug in __rmatmul__:
-    `return ((other.unsqueeze(-2) @ self.A) @ self.B).squeeze(-1)` is squeezing on the wrong dimension.
-
-    We could fix this by changing the argument to squeeze to `-2`. However there would be a small risk of
-    breaking consumers that assume the existing behaviour?
-    """
-)
 def test_right_matmul_by_vector():
     a = torch.rand(2, 3)
     b = torch.rand(3, 4)
@@ -47,16 +35,6 @@ def test_right_matmul_by_vector():
     assert_close(vector @ fm, vector @ (a @ b))
 
 
-@pytest.mark.skip(
-    """
-    See comment for [test_right_matmul_by_vector].
-
-    This time, error is
-    AssertionError: The values for attribute 'shape' do not match: torch.Size([6, 1, 4]) != torch.Size([6, 4]).
-
-    Fix would be the same.
-    """
-)
 def test_right_matmul_by_vector_leading_dim():
     a = torch.rand(6, 2, 3)
     b = torch.rand(6, 3, 4)

--- a/transformer_lens/FactoredMatrix.py
+++ b/transformer_lens/FactoredMatrix.py
@@ -58,7 +58,7 @@ class FactoredMatrix:
             ), f"Left matrix must match on inner dimension, shapes were self: {self.shape}, other:{other.shape}"
             if other.ndim < 2:
                 # It's a vector, so we collapse the factorisation and just return a vector
-                return ((other.unsqueeze(-2) @ self.A) @ self.B).squeeze(-1)
+                return ((other.unsqueeze(-2) @ self.A) @ self.B).squeeze(-2)
             elif self.ldim > self.mdim:
                 return FactoredMatrix(other @ self.A, self.B)
             else:


### PR DESCRIPTION
# Description

This PR fixes #225 by squeezing the correct dimension of a vector x FactoredMatrix multiplication result. As @rusheb mentions, there is a risk of breaking code for anyone who is currently assuming the output to have shape (1, ...). (Although I think this is realistically a pretty small risk?)

## Type of change

- [x ] Bug fix 
- [x ] Breaking change (fix that would cause existing functionality to not work as expected)

# Checklist:

- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility