### PR TITLE
Fix test_svd_property_leading_ones

### DIFF
--- a/tests/unit/factored_matrix/test_properties.py
+++ b/tests/unit/factored_matrix/test_properties.py
@@ -73,20 +73,15 @@ class TestFactoredMatrixProperties:
             assert torch.allclose(U.T @ U, torch.eye(U.shape[-1]), atol=1e-5)
             assert torch.allclose(Vh.T @ Vh, torch.eye(Vh.shape[-1]), atol=1e-5)
 
-    @pytest.mark.skip(
-        """
-        This test fails if there are leading ones. Talk to Neel about this.
-        """
-    )
     def test_svd_property_leading_ones(self, factored_matrices_leading_ones):
         for factored_matrix in factored_matrices_leading_ones:
             U, S, Vh = factored_matrix.svd()
             assert torch.allclose(
-                factored_matrix.AB, U @ torch.diag_embed(S) @ Vh.T, atol=1e-5
+                factored_matrix.AB, U @ torch.diag_embed(S) @ Vh.mT, atol=1e-5
             )
             # test that U and Vh are unitary
-            assert torch.allclose(U.T @ U, torch.eye(U.shape[-1]), atol=1e-5)
-            assert torch.allclose(Vh.T @ Vh, torch.eye(Vh.shape[-1]), atol=1e-5)
+            assert torch.allclose(U.mT @ U, torch.eye(U.shape[-1]), atol=1e-5)
+            assert torch.allclose(Vh.mT @ Vh, torch.eye(Vh.shape[-1]), atol=1e-5)
 
     @pytest.mark.skip(
         """


### PR DESCRIPTION
# Description

Fixes #226 by correcting test_svd_property_leading_ones. tensor.T reverses all dimensions of a tensor, while tensor.mT only transposes the last 2 (which is what we want here). https://pytorch.org/docs/stable/tensors.html#torch.Tensor.mT

## Type of change

- [x ] Bug fix

# Checklist:

- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility