### PR TITLE
Add apply_ln to stack_head_results and stack_neuron_results

### DIFF
--- a/tests/acceptance/test_activation_cache.py
+++ b/tests/acceptance/test_activation_cache.py
@@ -183,3 +183,23 @@ def test_stack_head_results_with_apply_ln():
     scaled_residual_stack = cache.stack_head_results(layer=-1, pos_slice=-1, apply_ln=True)
 
     assert torch.isclose(ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7).all()
+
+@torch.set_grad_enabled(False)
+def test_stack_neuron_results_with_apply_ln():
+
+    # Load solu-2l
+    model = load_model('solu-2l')
+
+    tokens, _ = get_ioi_tokens_and_answer_tokens(model)
+
+    # Run the model and cache all activations
+    _, cache = model.run_with_cache(tokens)
+
+    # Get neuron result stack and apply ln seperately
+    neuron_result_stack = cache.stack_neuron_results(layer=-1, pos_slice=-1)
+    ref_scaled_residual_stack = cache.apply_ln_to_stack(neuron_result_stack, layer=-1, pos_slice=-1)
+    
+    # Get scaled_residual_stack using apply_ln parameter
+    scaled_residual_stack = cache.stack_neuron_results(layer=-1, pos_slice=-1, apply_ln=True)
+
+    assert torch.isclose(ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7).all()

--- a/tests/acceptance/test_activation_cache.py
+++ b/tests/acceptance/test_activation_cache.py
@@ -163,3 +163,23 @@ def test_decompose_resid_with_apply_ln():
     scaled_residual_stack = cache.decompose_resid(layer=-1, pos_slice=-1, apply_ln=True)
 
     assert torch.isclose(ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7).all()
+
+@torch.set_grad_enabled(False)
+def test_stack_head_results_with_apply_ln():
+
+    # Load solu-2l
+    model = load_model('solu-2l')
+
+    tokens, _ = get_ioi_tokens_and_answer_tokens(model)
+
+    # Run the model and cache all activations
+    _, cache = model.run_with_cache(tokens)
+
+    # Get per head resid stack and apply ln seperately (cribbed notebook code)
+    per_head_residual = cache.stack_head_results(layer=-1, pos_slice=-1)
+    ref_scaled_residual_stack = cache.apply_ln_to_stack(per_head_residual, layer=-1, pos_slice=-1)
+    
+    # Get scaled_residual_stack using apply_ln parameter
+    scaled_residual_stack = cache.stack_head_results(layer=-1, pos_slice=-1, apply_ln=True)
+
+    assert torch.isclose(ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7).all()

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -349,7 +349,7 @@ class ActivationCache:
         Args:
             layer (int): Layer index - heads at all layers strictly before this are included. layer must be in [1, n_layers-1], or any of (n_layers, -1, None), which all mean the final layer
             return_labels (bool, optional): Whether to also return a list of labels of the form "L0H0" for the heads. Defaults to False.
-            # incl_remainder (bool, optional): Whether to return a final term which is "the rest of the residual stream". Defaults to False.
+            incl_remainder (bool, optional): Whether to return a final term which is "the rest of the residual stream". Defaults to False.
             pos_slice (Slice): A slice object to apply to the pos dimension. Defaults to None, do nothing.
             apply_ln (bool, optional): Whether to apply LayerNorm to the stack. Defaults to False.
         """
@@ -394,10 +394,12 @@ class ActivationCache:
                 *pos_slice.apply(self["hook_embed"], dim=-2).shape,
                 device=self.model.cfg.device,
             )
+
         if apply_ln:
             components = self.apply_ln_to_stack(
                 components, layer, pos_slice=pos_slice
             )
+            
         if return_labels:
             return components, labels
         else:


### PR DESCRIPTION
# Description

Previously I added an apply_ln parameter to accumulated_resid and decompose_resid in PR #220 to address issue #209 . After using them, I'm noticing it's also natural to make an analogous call to stack_head_results and stack_neuron_results (like when doing direct logit attribution). This PR adds the same functionality to stack_head_results and stack_neuron_results so they are all consistent. I also deleted a line from the stack_head_results doc string which doesn't seem true.

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

# Checklist:

- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility