### PR TITLE
Allow to_str_tokens of 1x1 tensors and add HookedTransformer.to_singl…

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -487,13 +487,15 @@ class HookedTransformer(HookedRootModule):
             tokens = self.to_tokens(input, prepend_bos=prepend_bos)[0]
         elif isinstance(input, torch.Tensor):
             tokens = input
-            tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            if tokens.dim() > 1:
+                tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
             assert (
                 tokens.dim() == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
         elif isinstance(input, np.ndarray):
             tokens = input
-            tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            if tokens.ndim > 1:
+                tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
             assert (
                 tokens.ndim == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
@@ -512,6 +514,12 @@ class HookedTransformer(HookedRootModule):
         # If token shape is non-empty, raise error
         assert not token.shape, f"Input string: {string} is not a single token!"
         return token.item()
+
+    def to_single_str_token(self, int_token: int) -> str:
+        # Gives the single token corresponding to an int, in string form
+        assert isinstance(int_token, int)
+        token = self.to_str_tokens(torch.tensor([int_token]))
+        return token[0]
 
     def get_token_position(
         self,


### PR DESCRIPTION
…e_str_token

# Description

-Makes HookedTransformer.to_str_tokens work on 1x1 tensors and numpy arrays
-Creates HookedTransformer.to_single_str_token, which takes in a single int and returns the string version of that token

Before:

In [11]: HookedTransformer(cfg).to_str_tokens(torch.tensor([2]))
Using pad_token, but it is not set yet.
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In [11], line 1
----> 1 HookedTransformer(cfg).to_str_tokens(torch.tensor([2]))

File ~/TransformerLens/transformer_lens/HookedTransformer.py:492, in HookedTransformer.to_str_tokens(self, input, prepend_bos)
    490     # if tokens.dim() > 1:
    491     tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
--> 492     assert (
    493         tokens.dim() == 1
    494     ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
    495 elif isinstance(input, np.ndarray):
    496     tokens = input

AssertionError: Invalid tokens input to to_str_tokens, has shape: torch.Size([])

After:

(Adds new functionality)

In [8]: HookedTransformer(cfg).to_str_tokens(torch.tensor([2]))
Using pad_token, but it is not set yet.
Out[8]: ['#']

In [9]: HookedTransformer(cfg).to_single_str_token(2)
Using pad_token, but it is not set yet.
Out[9]: '#'

In [13]: HookedTransformer(cfg).to_str_tokens(np.array([2]))
Using pad_token, but it is not set yet.
Out[13]: ['#']

(Does not change existing functionality)

In [23]: HookedTransformer(cfg).to_str_tokens(torch.tensor([[[[[1],[2],[3]]]]]))
Using pad_token, but it is not set yet.
Out[23]: ['"', '#', '$']

In [24]: HookedTransformer(cfg).to_str_tokens(np.array([[[[[1],[2],[3]]]]]))
Using pad_token, but it is not set yet.
Out[24]: ['"', '#', '$']

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->