### PR TITLE
Allow to_str_tokens of 1x1 tensors and add HookedTransformer.to_singl…

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -57,56 +57,55 @@ class TestSlice:
 
 MODEL = "solu-1l"
 
-prompt = "Hello World!"
 model = HookedTransformer.from_pretrained(MODEL)
 
 @pytest.fixture
-def nested_list_1x1():
+def nested_list_1():
     return [1]
 
 
 @pytest.fixture
-def nested_list_1x1x1x1():
-    return [[[[6]]]]
+def nested_list_1x1():
+    return [[6]]
 
 
 @pytest.fixture
-def nested_list_1x1x1x3x1():
-    return [[[[[1],[2],[3]]]]]
+def nested_list_1x3():
+    return [[1, 2, 3]]
 
 
-def test_to_str_tokens(nested_list_1x1, nested_list_1x1x1x1, nested_list_1x1x1x3x1):
+def test_to_str_tokens(nested_list_1, nested_list_1x1, nested_list_1x3):
+    tensor_1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1))
+    assert isinstance(tensor_1_to_str_tokens, list)
+    assert len(tensor_1_to_str_tokens) == 1
+    assert isinstance(tensor_1_to_str_tokens[0], str)
+
     tensor_1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1))
     assert isinstance(tensor_1x1_to_str_tokens, list)
     assert len(tensor_1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1_to_str_tokens[0], str)
 
-    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x1))
-    assert isinstance(tensor_1x1x1x1_to_str_tokens, list)
-    assert len(tensor_1x1x1x1_to_str_tokens) == 1
-    assert isinstance(tensor_1x1x1x1_to_str_tokens[0], str)
+    ndarray_1_to_str_tokens = model.to_str_tokens(np.array(nested_list_1))
+    assert isinstance(ndarray_1_to_str_tokens, list)
+    assert len(ndarray_1_to_str_tokens) == 1
+    assert isinstance(ndarray_1_to_str_tokens[0], str)
 
     ndarray_1x1_to_str_tokens = model.to_str_tokens(np.array(nested_list_1x1))
     assert isinstance(ndarray_1x1_to_str_tokens, list)
     assert len(ndarray_1x1_to_str_tokens) == 1
     assert isinstance(ndarray_1x1_to_str_tokens[0], str)
 
-    ndarray_1x1x1x1_to_str_tokens = model.to_str_tokens(np.array(nested_list_1x1x1x1))
-    assert isinstance(ndarray_1x1x1x1_to_str_tokens, list)
-    assert len(ndarray_1x1x1x1_to_str_tokens) == 1
-    assert isinstance(ndarray_1x1x1x1_to_str_tokens[0], str)
-
     single_int_to_single_str_token = model.to_single_str_token(3)
     assert isinstance(single_int_to_single_str_token, str)
 
-    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x3x1))
+    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x3))
     assert isinstance(squeezable_tensor_to_str_tokens, list)
     assert len(squeezable_tensor_to_str_tokens) == 3
     assert isinstance(squeezable_tensor_to_str_tokens[0], str)
     assert isinstance(squeezable_tensor_to_str_tokens[1], str)
     assert isinstance(squeezable_tensor_to_str_tokens[2], str)
 
-    squeezable_ndarray_to_str_tokens = model.to_str_tokens(np.array(nested_list_1x1x1x3x1))
+    squeezable_ndarray_to_str_tokens = model.to_str_tokens(np.array(nested_list_1x3))
     assert isinstance(squeezable_ndarray_to_str_tokens, list)
     assert len(squeezable_ndarray_to_str_tokens) == 3
     assert isinstance(squeezable_ndarray_to_str_tokens[0], str)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -76,12 +76,12 @@ def nested_list_1x1x1x3x1():
 
 
 def test_to_str_tokens(nested_list_1x1, nested_list_1x1x1x1, nested_list_1x1x1x3x1):
-    tensor_1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1))
+    tensor_1x1_to_str_tokens = model.to_str_tokens(torch.Tensor(nested_list_1x1))
     assert isinstance(tensor_1x1_to_str_tokens, list)
     assert len(tensor_1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1_to_str_tokens[0], str)
 
-    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x1))
+    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.Tensor(nested_list_1x1x1x1))
     assert isinstance(tensor_1x1x1x1_to_str_tokens, list)
     assert len(tensor_1x1x1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1x1x1_to_str_tokens[0], str)
@@ -99,7 +99,7 @@ def test_to_str_tokens(nested_list_1x1, nested_list_1x1x1x1, nested_list_1x1x1x3
     single_int_to_single_str_token = model.to_single_str_token(3)
     assert isinstance(single_int_to_single_str_token, str)
 
-    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x3x1))
+    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.Tensor(nested_list_1x1x1x3x1))
     assert isinstance(squeezable_tensor_to_str_tokens, list)
     assert len(squeezable_tensor_to_str_tokens) == 3
     assert isinstance(squeezable_tensor_to_str_tokens[0], str)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -66,10 +66,20 @@ def test_to_str_tokens():
     assert len(tensor_1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1_to_str_tokens[0], str)
 
+    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.tensor([[[[6]]]]))
+    assert isinstance(tensor_1x1x1x1_to_str_tokens, list)
+    assert len(tensor_1x1x1x1_to_str_tokens) == 1
+    assert isinstance(tensor_1x1x1x1_to_str_tokens[0], str)
+
     ndarray_1x1_to_str_tokens = model.to_str_tokens(np.array([2]))
     assert isinstance(ndarray_1x1_to_str_tokens, list)
     assert len(ndarray_1x1_to_str_tokens) == 1
     assert isinstance(ndarray_1x1_to_str_tokens[0], str)
+
+    ndarray_1x1x1x1_to_str_tokens = model.to_str_tokens(np.array([[[[3]]]]))
+    assert isinstance(ndarray_1x1x1x1_to_str_tokens, list)
+    assert len(ndarray_1x1x1x1_to_str_tokens) == 1
+    assert isinstance(ndarray_1x1x1x1_to_str_tokens[0], str)
 
     single_int_to_single_str_token = model.to_single_str_token(3)
     assert isinstance(single_int_to_single_str_token, str)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,6 +3,7 @@ import torch
 import numpy as np
 
 import transformer_lens.utils as utils
+from transformer_lens import HookedTransformer
 
 ref_tensor = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
 shape = ref_tensor.shape
@@ -52,3 +53,37 @@ class TestSlice:
     def test_indices_error(self):
         with pytest.raises(ValueError):
             _ = utils.Slice(input_slice=[0, 2, 5]).indices()
+
+
+MODEL = "solu-1l"
+
+prompt = "Hello World!"
+model = HookedTransformer.from_pretrained(MODEL)
+
+def test_to_str_tokens():
+    tensor_1x1_to_str_tokens = model.to_str_tokens(torch.tensor([1]))
+    assert isinstance(tensor_1x1_to_str_tokens, list)
+    assert len(tensor_1x1_to_str_tokens) == 1
+    assert isinstance(tensor_1x1_to_str_tokens[0], str)
+
+    ndarray_1x1_to_str_tokens = model.to_str_tokens(np.array([2]))
+    assert isinstance(ndarray_1x1_to_str_tokens, list)
+    assert len(ndarray_1x1_to_str_tokens) == 1
+    assert isinstance(ndarray_1x1_to_str_tokens[0], str)
+
+    single_int_to_single_str_token = model.to_single_str_token(3)
+    assert isinstance(single_int_to_single_str_token, str)
+
+    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.tensor([[[[[1],[2],[3]]]]]))
+    assert isinstance(squeezable_tensor_to_str_tokens, list)
+    assert len(squeezable_tensor_to_str_tokens) == 3
+    assert isinstance(squeezable_tensor_to_str_tokens[0], str)
+    assert isinstance(squeezable_tensor_to_str_tokens[1], str)
+    assert isinstance(squeezable_tensor_to_str_tokens[2], str)
+
+    squeezable_ndarray_to_str_tokens = model.to_str_tokens(np.array([[[[[1],[2],[3]]]]]))
+    assert isinstance(squeezable_ndarray_to_str_tokens, list)
+    assert len(squeezable_ndarray_to_str_tokens) == 3
+    assert isinstance(squeezable_ndarray_to_str_tokens[0], str)
+    assert isinstance(squeezable_ndarray_to_str_tokens[1], str)
+    assert isinstance(squeezable_ndarray_to_str_tokens[2], str)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -60,23 +60,38 @@ MODEL = "solu-1l"
 prompt = "Hello World!"
 model = HookedTransformer.from_pretrained(MODEL)
 
-def test_to_str_tokens():
-    tensor_1x1_to_str_tokens = model.to_str_tokens(torch.tensor([1]))
+@pytest.fixture
+def nested_list_1x1():
+    return [1]
+
+
+@pytest.fixture
+def nested_list_1x1x1x1():
+    return [[[[6]]]]
+
+
+@pytest.fixture
+def nested_list_1x1x1x3x1():
+    return [[[[[1],[2],[3]]]]]
+
+
+def test_to_str_tokens(nested_list_1x1, nested_list_1x1x1x1, nested_list_1x1x1x3x1):
+    tensor_1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1))
     assert isinstance(tensor_1x1_to_str_tokens, list)
     assert len(tensor_1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1_to_str_tokens[0], str)
 
-    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.tensor([[[[6]]]]))
+    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x1))
     assert isinstance(tensor_1x1x1x1_to_str_tokens, list)
     assert len(tensor_1x1x1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1x1x1_to_str_tokens[0], str)
 
-    ndarray_1x1_to_str_tokens = model.to_str_tokens(np.array([2]))
+    ndarray_1x1_to_str_tokens = model.to_str_tokens(np.array(nested_list_1x1))
     assert isinstance(ndarray_1x1_to_str_tokens, list)
     assert len(ndarray_1x1_to_str_tokens) == 1
     assert isinstance(ndarray_1x1_to_str_tokens[0], str)
 
-    ndarray_1x1x1x1_to_str_tokens = model.to_str_tokens(np.array([[[[3]]]]))
+    ndarray_1x1x1x1_to_str_tokens = model.to_str_tokens(np.array(nested_list_1x1x1x1))
     assert isinstance(ndarray_1x1x1x1_to_str_tokens, list)
     assert len(ndarray_1x1x1x1_to_str_tokens) == 1
     assert isinstance(ndarray_1x1x1x1_to_str_tokens[0], str)
@@ -84,14 +99,14 @@ def test_to_str_tokens():
     single_int_to_single_str_token = model.to_single_str_token(3)
     assert isinstance(single_int_to_single_str_token, str)
 
-    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.tensor([[[[[1],[2],[3]]]]]))
+    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x3x1))
     assert isinstance(squeezable_tensor_to_str_tokens, list)
     assert len(squeezable_tensor_to_str_tokens) == 3
     assert isinstance(squeezable_tensor_to_str_tokens[0], str)
     assert isinstance(squeezable_tensor_to_str_tokens[1], str)
     assert isinstance(squeezable_tensor_to_str_tokens[2], str)
 
-    squeezable_ndarray_to_str_tokens = model.to_str_tokens(np.array([[[[[1],[2],[3]]]]]))
+    squeezable_ndarray_to_str_tokens = model.to_str_tokens(np.array(nested_list_1x1x1x3x1))
     assert isinstance(squeezable_ndarray_to_str_tokens, list)
     assert len(squeezable_ndarray_to_str_tokens) == 3
     assert isinstance(squeezable_ndarray_to_str_tokens[0], str)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -76,12 +76,12 @@ def nested_list_1x1x1x3x1():
 
 
 def test_to_str_tokens(nested_list_1x1, nested_list_1x1x1x1, nested_list_1x1x1x3x1):
-    tensor_1x1_to_str_tokens = model.to_str_tokens(torch.Tensor(nested_list_1x1))
+    tensor_1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1))
     assert isinstance(tensor_1x1_to_str_tokens, list)
     assert len(tensor_1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1_to_str_tokens[0], str)
 
-    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.Tensor(nested_list_1x1x1x1))
+    tensor_1x1x1x1_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x1))
     assert isinstance(tensor_1x1x1x1_to_str_tokens, list)
     assert len(tensor_1x1x1x1_to_str_tokens) == 1
     assert isinstance(tensor_1x1x1x1_to_str_tokens[0], str)
@@ -99,7 +99,7 @@ def test_to_str_tokens(nested_list_1x1, nested_list_1x1x1x1, nested_list_1x1x1x3
     single_int_to_single_str_token = model.to_single_str_token(3)
     assert isinstance(single_int_to_single_str_token, str)
 
-    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.Tensor(nested_list_1x1x1x3x1))
+    squeezable_tensor_to_str_tokens = model.to_str_tokens(torch.tensor(nested_list_1x1x1x3x1))
     assert isinstance(squeezable_tensor_to_str_tokens, list)
     assert len(squeezable_tensor_to_str_tokens) == 3
     assert isinstance(squeezable_tensor_to_str_tokens[0], str)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -487,13 +487,15 @@ class HookedTransformer(HookedRootModule):
             tokens = self.to_tokens(input, prepend_bos=prepend_bos)[0]
         elif isinstance(input, torch.Tensor):
             tokens = input
-            tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            if tokens.dim() > 1:
+                tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
             assert (
                 tokens.dim() == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
         elif isinstance(input, np.ndarray):
             tokens = input
-            tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            if tokens.ndim > 1:
+                tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
             assert (
                 tokens.ndim == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
@@ -512,6 +514,12 @@ class HookedTransformer(HookedRootModule):
         # If token shape is non-empty, raise error
         assert not token.shape, f"Input string: {string} is not a single token!"
         return token.item()
+
+    def to_single_str_token(self, int_token: int) -> str:
+        # Gives the single token corresponding to an int, in string form
+        assert isinstance(int_token, int)
+        token = self.to_str_tokens(torch.tensor([int_token]))
+        return token[0]
 
     def get_token_position(
         self,

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -460,7 +460,12 @@ class HookedTransformer(HookedRootModule):
 
     def to_str_tokens(
         self,
-        input: Union[str, Union[Float[torch.Tensor, "pos"], Float[torch.Tensor, "1 pos"]], list, torch.Tensor, np.ndarray],
+        input: Union[str,
+                     Float[torch.Tensor, "pos"],
+                     Float[torch.Tensor, "1 pos"],
+                     Float[np.ndarray, "pos"],
+                     Float[np.ndarray, "1 pos"],
+                     list],
         prepend_bos: bool = True,
     ) -> List[str]:
         """Method to map text, a list of text or tokens to a list of tokens as strings

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -487,15 +487,13 @@ class HookedTransformer(HookedRootModule):
             tokens = self.to_tokens(input, prepend_bos=prepend_bos)[0]
         elif isinstance(input, torch.Tensor):
             tokens = input
-            if tokens.dim() > 1:
-                tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            tokens = tokens.squeeze(dim=1)  # Get rid of a trivial batch dimension
             assert (
                 tokens.dim() == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
         elif isinstance(input, np.ndarray):
             tokens = input
-            if tokens.ndim > 1:
-                tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            tokens = tokens.squeeze(dim=1)  # Get rid of a trivial batch dimension
             assert (
                 tokens.ndim == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -525,7 +525,7 @@ class HookedTransformer(HookedRootModule):
         return token.item()
 
     def to_single_str_token(self, int_token: int) -> str:
-        # Gives the single token corresponding to an int, in string form
+        # Gives the single token corresponding to an int in string form
         assert isinstance(int_token, int)
         token = self.to_str_tokens(torch.tensor([int_token]))
         assert len(token) == 1

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -461,10 +461,10 @@ class HookedTransformer(HookedRootModule):
     def to_str_tokens(
         self,
         input: Union[str,
-                     Int[torch.tensor, "pos"],
-                     Int[torch.tensor, "1 pos"],
-                     Float[np.ndarray, "pos"],
-                     Float[np.ndarray, "1 pos"],
+                     Int[torch.Tensor, "pos"],
+                     Int[torch.Tensor, "1 pos"],
+                     Int[np.ndarray, "pos"],
+                     Int[np.ndarray, "1 pos"],
                      list],
         prepend_bos: bool = True,
     ) -> List[str]:

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -493,14 +493,18 @@ class HookedTransformer(HookedRootModule):
         elif isinstance(input, torch.Tensor):
             tokens = input
             tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
-            tokens = tokens.unsqueeze(0) if tokens.dim() == 0 else tokens  # Don't pass dimensionless tensor
+            if tokens.dim() == 0:
+                # Don't pass dimensionless tensor
+                tokens = tokens.unsqueeze(0)
             assert (
                 tokens.dim() == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
         elif isinstance(input, np.ndarray):
             tokens = input
             tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
-            tokens = np.expand_dims(tokens, axis=0) if tokens.ndim == 0 else tokens  # Don't pass dimensionless tensor
+            if tokens.ndim == 0:
+                # Don't pass dimensionless tensor
+                tokens = np.expand_dims(tokens, axis=0)
             assert (
                 tokens.ndim == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
@@ -524,6 +528,7 @@ class HookedTransformer(HookedRootModule):
         # Gives the single token corresponding to an int, in string form
         assert isinstance(int_token, int)
         token = self.to_str_tokens(torch.tensor([int_token]))
+        assert len(token) == 1
         return token[0]
 
     def get_token_position(

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -487,13 +487,15 @@ class HookedTransformer(HookedRootModule):
             tokens = self.to_tokens(input, prepend_bos=prepend_bos)[0]
         elif isinstance(input, torch.Tensor):
             tokens = input
-            tokens = tokens.squeeze(dim=1)  # Get rid of a trivial batch dimension
+            tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            tokens = tokens.unsqueeze(0) if tokens.dim() == 0 else tokens  # Don't pass dimensionless tensor
             assert (
                 tokens.dim() == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
         elif isinstance(input, np.ndarray):
             tokens = input
-            tokens = tokens.squeeze(dim=1)  # Get rid of a trivial batch dimension
+            tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
+            tokens = np.expand_dims(tokens, axis=0) if tokens.ndim == 0 else tokens  # Don't pass dimensionless tensor
             assert (
                 tokens.ndim == 1
             ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -461,8 +461,8 @@ class HookedTransformer(HookedRootModule):
     def to_str_tokens(
         self,
         input: Union[str,
-                     Float[torch.Tensor, "pos"],
-                     Float[torch.Tensor, "1 pos"],
+                     Int[torch.tensor, "pos"],
+                     Int[torch.tensor, "1 pos"],
                      Float[np.ndarray, "pos"],
                      Float[np.ndarray, "1 pos"],
                      list],

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -460,7 +460,7 @@ class HookedTransformer(HookedRootModule):
 
     def to_str_tokens(
         self,
-        input: Union[str, Union[Float[torch.Tensor, "pos"], Float[torch.Tensor, "1 pos"]], list],
+        input: Union[str, Union[Float[torch.Tensor, "pos"], Float[torch.Tensor, "1 pos"]], list, torch.Tensor, np.ndarray],
         prepend_bos: bool = True,
     ) -> List[str]:
         """Method to map text, a list of text or tokens to a list of tokens as strings


### PR DESCRIPTION
…e_str_token

# Description

-Makes HookedTransformer.to_str_tokens work on 1x1 tensors and numpy arrays
-Creates HookedTransformer.to_single_str_token, which takes in a single int and returns the string version of that token

Before:

In [11]: HookedTransformer(cfg).to_str_tokens(torch.tensor([2]))
Using pad_token, but it is not set yet.
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In [11], line 1
----> 1 HookedTransformer(cfg).to_str_tokens(torch.tensor([2]))

File ~/TransformerLens/transformer_lens/HookedTransformer.py:492, in HookedTransformer.to_str_tokens(self, input, prepend_bos)
    490     # if tokens.dim() > 1:
    491     tokens = tokens.squeeze()  # Get rid of a trivial batch dimension
--> 492     assert (
    493         tokens.dim() == 1
    494     ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
    495 elif isinstance(input, np.ndarray):
    496     tokens = input

AssertionError: Invalid tokens input to to_str_tokens, has shape: torch.Size([])

After:

(Adds new functionality)

In [8]: HookedTransformer(cfg).to_str_tokens(torch.tensor([2]))
Using pad_token, but it is not set yet.
Out[8]: ['#']

In [9]: HookedTransformer(cfg).to_single_str_token(2)
Using pad_token, but it is not set yet.
Out[9]: '#'

In [13]: HookedTransformer(cfg).to_str_tokens(np.array([2]))
Using pad_token, but it is not set yet.
Out[13]: ['#']

(Does not change existing functionality)

In [23]: HookedTransformer(cfg).to_str_tokens(torch.tensor([[[[[1],[2],[3]]]]]))
Using pad_token, but it is not set yet.
Out[23]: ['"', '#', '$']

In [24]: HookedTransformer(cfg).to_str_tokens(np.array([[[[[1],[2],[3]]]]]))
Using pad_token, but it is not set yet.
Out[24]: ['"', '#', '$']

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->