### PR TITLE
Add tensor information to typeguard error messages

### DIFF
--- a/tests/unit/test_typecheck.py
+++ b/tests/unit/test_typecheck.py
@@ -1,37 +1,41 @@
 import re
 from textwrap import dedent
+
 import pytest
 import torch
 import typeguard
-from typeguard import typechecked
 from jaxtyping import Float
+from typeguard import typechecked
 
 from transformer_lens.typecheck import typecheck_fail_callback
 
 typeguard.config.typecheck_fail_callback = typecheck_fail_callback
 
+
 @typechecked
 def foo(x: int) -> int:
     return x + 1
+
 
 @typechecked
 def tensor_foo(
     x: Float[torch.Tensor, "a b"],
     y: Float[torch.Tensor, "b c"],
     z: Float[torch.Tensor, "c d"],
-    ) -> Float[torch.Tensor, "a d"]:
+) -> Float[torch.Tensor, "a d"]:
     return x @ y @ z
 
-def test_error_message_is_correct_with_tensor_args():
 
-    ref_err_msg = "argument \"x\" (str) is not an instance of int"
+def test_error_message_is_correct_with_tensor_args():
+    ref_err_msg = 'argument "x" (str) is not an instance of int'
 
     with pytest.raises(typeguard.TypeCheckError, match=re.escape(ref_err_msg)):
         foo("a")
 
-def test_error_message_is_correct_without_tensor_args():
 
-    ref_err_msg = dedent("""argument "y" (torch.Tensor) is not an instance of jaxtyping.Float[Tensor, 'b c']
+def test_error_message_is_correct_without_tensor_args():
+    ref_err_msg = dedent(
+        """argument "y" (torch.Tensor) is not an instance of jaxtyping.Float[Tensor, 'b c']
 tensor argument info:
 \tx  shape=(1, 2)     dtype=torch.float32
 \ty  shape=(2, 3, 5)  dtype=torch.float32
@@ -39,4 +43,4 @@ tensor argument info:
     )
 
     with pytest.raises(typeguard.TypeCheckError, match=re.escape(ref_err_msg)):
-        tensor_foo(torch.randn((1,2)), torch.randn((2,3,5)), torch.randn((3,4)))
+        tensor_foo(torch.randn((1, 2)), torch.randn((2, 3, 5)), torch.randn((3, 4)))

--- a/tests/unit/test_typecheck.py
+++ b/tests/unit/test_typecheck.py
@@ -1,0 +1,42 @@
+import re
+from textwrap import dedent
+import pytest
+import torch
+import typeguard
+from typeguard import typechecked
+from jaxtyping import Float
+
+from transformer_lens.typecheck import typecheck_fail_callback
+
+typeguard.config.typecheck_fail_callback = typecheck_fail_callback
+
+@typechecked
+def foo(x: int) -> int:
+    return x + 1
+
+@typechecked
+def tensor_foo(
+    x: Float[torch.Tensor, "a b"],
+    y: Float[torch.Tensor, "b c"],
+    z: Float[torch.Tensor, "c d"],
+    ) -> Float[torch.Tensor, "a d"]:
+    return x @ y @ z
+
+def test_error_message_is_correct_with_tensor_args():
+
+    ref_err_msg = "argument \"x\" (str) is not an instance of int"
+
+    with pytest.raises(typeguard.TypeCheckError, match=re.escape(ref_err_msg)):
+        foo("a")
+
+def test_error_message_is_correct_without_tensor_args():
+
+    ref_err_msg = dedent("""argument "y" (torch.Tensor) is not an instance of jaxtyping.Float[Tensor, 'b c']
+tensor argument info:
+\tx  shape=(1, 2)     dtype=torch.float32
+\ty  shape=(2, 3, 5)  dtype=torch.float32
+\tz  shape=(3, 4)     dtype=torch.float32"""
+    )
+
+    with pytest.raises(typeguard.TypeCheckError, match=re.escape(ref_err_msg)):
+        tensor_foo(torch.randn((1,2)), torch.randn((2,3,5)), torch.randn((3,4)))

--- a/transformer_lens/__init__.py
+++ b/transformer_lens/__init__.py
@@ -21,3 +21,8 @@ from .past_key_value_caching import (
 )
 from .HookedTransformer import HookedTransformer as EasyTransformer
 from .HookedTransformerConfig import HookedTransformerConfig as EasyTransformerConfig
+
+# Set up custom error message for typeguard
+import typeguard
+from .typecheck import typecheck_fail_callback
+typeguard.config.typecheck_fail_callback = typecheck_fail_callback

--- a/transformer_lens/__init__.py
+++ b/transformer_lens/__init__.py
@@ -25,4 +25,5 @@ from .HookedTransformerConfig import HookedTransformerConfig as EasyTransformerC
 # Set up custom error message for typeguard
 import typeguard
 from .typecheck import typecheck_fail_callback
+
 typeguard.config.typecheck_fail_callback = typecheck_fail_callback

--- a/transformer_lens/typecheck.py
+++ b/transformer_lens/typecheck.py
@@ -1,14 +1,22 @@
 import torch
 import typeguard
 
+
 def typecheck_fail_callback(err, memo):
     """Callback for typeguard to print out tensor shapes and dtypes on type errors"""
-    tensor_arg_names = tuple(key for key in memo.locals.keys() if isinstance(memo.locals[key], torch.Tensor))
+    tensor_arg_names = tuple(
+        key for key in memo.locals.keys() if isinstance(memo.locals[key], torch.Tensor)
+    )
     if tensor_arg_names:
         max_arg_name_len = max(len(arg_name) for arg_name in tensor_arg_names)
-        arg_shape_strs = tuple(str(tuple(memo.locals[arg_name].shape)) for arg_name in tensor_arg_names)
+        arg_shape_strs = tuple(
+            str(tuple(memo.locals[arg_name].shape)) for arg_name in tensor_arg_names
+        )
         max_arg_shape_len = max(len(arg_shape_str) for arg_shape_str in arg_shape_strs)
-        tensor_arg_shapes = (f"{arg_name:<{max_arg_name_len + 1}} shape={arg_shape_str:<{max_arg_shape_len + 1}} dtype={memo.locals[arg_name].dtype}" for arg_name, arg_shape_str in zip(tensor_arg_names, arg_shape_strs))
+        tensor_arg_shapes = (
+            f"{arg_name:<{max_arg_name_len + 1}} shape={arg_shape_str:<{max_arg_shape_len + 1}} dtype={memo.locals[arg_name].dtype}"
+            for arg_name, arg_shape_str in zip(tensor_arg_names, arg_shape_strs)
+        )
         err_msg = str(err)
         err_msg += "\ntensor argument info:\n\t"
         err_msg += "\n\t".join(tensor_arg_shapes)

--- a/transformer_lens/typecheck.py
+++ b/transformer_lens/typecheck.py
@@ -1,0 +1,16 @@
+import torch
+import typeguard
+
+def typecheck_fail_callback(err, memo):
+    """Callback for typeguard to print out tensor shapes and dtypes on type errors"""
+    tensor_arg_names = tuple(key for key in memo.locals.keys() if isinstance(memo.locals[key], torch.Tensor))
+    if tensor_arg_names:
+        max_arg_name_len = max(len(arg_name) for arg_name in tensor_arg_names)
+        arg_shape_strs = tuple(str(tuple(memo.locals[arg_name].shape)) for arg_name in tensor_arg_names)
+        max_arg_shape_len = max(len(arg_shape_str) for arg_shape_str in arg_shape_strs)
+        tensor_arg_shapes = (f"{arg_name:<{max_arg_name_len + 1}} shape={arg_shape_str:<{max_arg_shape_len + 1}} dtype={memo.locals[arg_name].dtype}" for arg_name, arg_shape_str in zip(tensor_arg_names, arg_shape_strs))
+        err_msg = str(err)
+        err_msg += "\ntensor argument info:\n\t"
+        err_msg += "\n\t".join(tensor_arg_shapes)
+        raise typeguard.TypeCheckError(err_msg)
+    raise err

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -14,7 +14,7 @@ from huggingface_hub import hf_hub_download
 from rich import print as rprint
 from transformers import AutoTokenizer
 
-from transformer_lens import FactoredMatrix
+from transformer_lens.FactoredMatrix import FactoredMatrix
 
 CACHE_DIR = transformers.TRANSFORMERS_CACHE
 import json


### PR DESCRIPTION
# Description

Fixes #190

This PR adds tensor argument shape and dtype information to the typeguard error message by providing  a `typeguard_fail_callback` function to typeguard.

For example
```
@typechecked
def tensor_foo(
    x: Float[torch.Tensor, "a b"],
    y: Float[torch.Tensor, "b c"],
    z: Float[torch.Tensor, "c d"],
    ) -> Float[torch.Tensor, "a d"]:
    return x @ y @ z

tensor_foo(torch.randn((1,2)), torch.randn((2,3,5)), torch.randn((3,4)))    
```

will print

```
got error: argument "y" (torch.Tensor) is not an instance of jaxtyping.Float[Tensor, 'b c']
tensor argument info:
        x  shape=(1, 2)     dtype=torch.float32
        y  shape=(2, 3, 5)  dtype=torch.float32
        z  shape=(3, 4)     dtype=torch.float32
```

The callback feature was introduced in typeguard 3, so I upgraded typeguard to 3.0.2, which required changing the python requirement slightly (from >=3.7 to >=3.7.4)

I first considered monkeypatching typeguard, but this solution seems adequate and much less brittle.  I'd like to print something like "Shape mismatch" too, but I'd have to rewrite the logic from jaxtyping to detect that is the case.

One thing to consider- to enable typechecking, we have to add that `install_import_hook("transformer_lens", ("typeguard", "typechecked"))` bit everywhere we use transformer lens.  Not sure if there's any way around that.

Note: I also want to include the type hints in the error message, but for some reason they seem to be removed from typeguard 4.  I'm inquiring why here: https://github.com/agronholm/typeguard/discussions/345 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
N/A

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility