### PR TITLE
fix outdated link in Exploratory Analysis Demo

### DIFF
--- a/demos/Exploratory_Analysis_Demo.ipynb
+++ b/demos/Exploratory_Analysis_Demo.ipynb
@@ -259,7 +259,7 @@
                 "\n",
                 "This is a demo notebook for [TransformerLens](https://github.com/neelnanda-io/TransformerLens), a library for mechanistic interpretability of GPT-2 style transformer language models. A core design principle of the library is to enable exploratory analysis - one of the most fun parts of mechanistic interpretability compared to normal ML is the extremely short feedback loops! The point of this library is to keep the gap between having an experiment idea and seeing the results as small as possible, to make it Hooked for **research to feel like play** and to enter a flow state.\n",
                 "\n",
-                "The goal of this notebook is to demonstrate what exploratory analysis looks like in practice with the library. I use my standard toolkit of basic mechanistic interpretability techniques to try interpreting a real circuit in GPT-2 small. Check out [the main demo](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/main/Main_Demo.ipynb) for an introduction to the library and how to use it. \n",
+                "The goal of this notebook is to demonstrate what exploratory analysis looks like in practice with the library. I use my standard toolkit of basic mechanistic interpretability techniques to try interpreting a real circuit in GPT-2 small. Check out [the main demo](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/main/demos/Main_Demo.ipynb) for an introduction to the library and how to use it. \n",
                 "\n",
                 "Stylistically, I will go fairly slowly and explain in detail what I'm doing and why, aiming to help convey how to do this kind of research yourself! But the code itself is written to be simple and generic, and Hooked to copy and paste into your own projects for different tasks and models.\n",
                 "\n",
@@ -1203,7 +1203,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "**This section explains how to do activation patching conceptually by implementing it from scratch. To use it in practice with TransformerLens, see [this demonstration instead](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/main/activation_patching_in_TL_demo.py.ipynb)**\n",
+                "**This section explains how to do activation patching conceptually by implementing it from scratch. To use it in practice with TransformerLens, see [this demonstration instead](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/main/demos/Activation_Patching_in_TL_Demo.ipynb)**\n",
                 "\n",
                 "The obvious limitation to the techniques used above is that they only look at the very end of the circuit - the parts that directly affect the logits. Clearly this is not sufficient to understand the circuit! We want to understand how things compose together to produce this final output, and ideally to produce an end-to-end circuit fully explaining this behaviour. \n",
                 "\n",


### PR DESCRIPTION
In the exploratory analysis demo, update the outdated link to the Main_Demo in the introduction section and Activation_Patching_in_TL_Demo in the activation patching section.