### PR TITLE
Fix `from_pretrained` with `redwood_attn_2l`

### DIFF
--- a/tests/acceptance/test_transformer_lens.py
+++ b/tests/acceptance/test_transformer_lens.py
@@ -70,12 +70,6 @@ def test_from_pretrained_no_processing(name, expected_loss):
     print(loss.item())
     assert (loss.item() - expected_loss) < 4e-5
 
-def test_shortformer_fold_ln_override():
-    """It's not possible to fold_ln with Shortformer, so check that when fold_ln is True, this is automatically overwritten (there is no crash)"""
-
-    # test_from_pretrained_no_processing("redwood_attn_2l", no_processing["redwood_attn_2l"], fold_ln=True)
-    test_model("redwood_attn_2l", no_processing["redwood_attn_2l"])
-
 @torch.no_grad()
 def test_pos_embed_hook():
     """

--- a/tests/acceptance/test_transformer_lens.py
+++ b/tests/acceptance/test_transformer_lens.py
@@ -39,10 +39,12 @@ loss_store = {
     "attn-only-3l": 5.747507095336914,
     "pythia": 4.659344673156738,
     "gelu-2l": 6.501802444458008,
+    "redwood_attn_2l": 10.530948638916016,
+    "solu-1l": 5.256411552429199,
 }
 no_processing = {
-    "solu-1l": 5.256411552429199,
-    "redwood_attn_2l": 10.530948638916016,
+    "solu-1l": loss_store["solu-1l"],
+    "redwood_attn_2l": loss_store["redwood_attn_2l"],
 }
 
 
@@ -63,12 +65,9 @@ def test_from_pretrained_no_processing(name, expected_loss, fold_ln=False):
     model_override = HookedTransformer.from_pretrained(name, fold_ln=fold_ln, center_writing_weights=False, center_unembed=False, refactor_factored_attn_matrices=False)
     assert model_ref.cfg == model_override.cfg
 
-    if name != "redwood_attn_2l": # TODO can't be loaded with from_pretrained
-        # Do the converse check, i.e. check that overriding boolean flags in
-        # from_pretrained_no_processing is equivalent to using from_pretrained
-        model_ref = HookedTransformer.from_pretrained(name)
-        model_override = HookedTransformer.from_pretrained_no_processing(name, fold_ln=fold_ln, center_writing_weights=True, center_unembed=True, refactor_factored_attn_matrices=False)
-        assert model_ref.cfg == model_override.cfg
+    model_ref = HookedTransformer.from_pretrained(name)
+    model_override = HookedTransformer.from_pretrained_no_processing(name, fold_ln=fold_ln, center_writing_weights=True, center_unembed=True, refactor_factored_attn_matrices=False)
+    assert model_ref.cfg == model_override.cfg
 
     # also check losses
     loss = model_ref(text, return_type="loss")
@@ -78,7 +77,8 @@ def test_from_pretrained_no_processing(name, expected_loss, fold_ln=False):
 def test_shortformer_fold_ln_override():
     """It's not possible to fold_ln with Shortformer, so check that when fold_ln is True, this is automatically overwritten (there is no crash)"""
 
-    test_from_pretrained_no_processing("redwood_attn_2l", no_processing["redwood_attn_2l"], fold_ln=True)
+    # test_from_pretrained_no_processing("redwood_attn_2l", no_processing["redwood_attn_2l"], fold_ln=True)
+    test_model("redwood_attn_2l", no_processing["redwood_attn_2l"])
 
 @torch.no_grad()
 def test_pos_embed_hook():

--- a/tests/acceptance/test_transformer_lens.py
+++ b/tests/acceptance/test_transformer_lens.py
@@ -57,16 +57,12 @@ def test_model(name, expected_loss):
 
 
 @pytest.mark.parametrize("name,expected_loss", list(no_processing.items()))
-def test_from_pretrained_no_processing(name, expected_loss, fold_ln=False):
+def test_from_pretrained_no_processing(name, expected_loss):
     # Checks if manually overriding the boolean flags in from_pretrained
     # is equivalent to using from_pretrained_no_processing
 
     model_ref = HookedTransformer.from_pretrained_no_processing(name)
-    model_override = HookedTransformer.from_pretrained(name, fold_ln=fold_ln, center_writing_weights=False, center_unembed=False, refactor_factored_attn_matrices=False)
-    assert model_ref.cfg == model_override.cfg
-
-    model_ref = HookedTransformer.from_pretrained(name)
-    model_override = HookedTransformer.from_pretrained_no_processing(name, fold_ln=fold_ln, center_writing_weights=True, center_unembed=True, refactor_factored_attn_matrices=False)
+    model_override = HookedTransformer.from_pretrained(name, fold_ln=False, center_writing_weights=False, center_unembed=False, refactor_factored_attn_matrices=False)
     assert model_ref.cfg == model_override.cfg
 
     # also check losses

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -749,9 +749,17 @@ class HookedTransformer(HookedRootModule):
             n_devices=n_devices,
         )
 
-        if cfg.positional_embedding_type == "shortformer" and fold_ln:
-            logging.warning("You tried to specify fold_ln=True for a shortformer model, but this can't be done! Setting fold_ln=False instead.")
-            fold_ln = False
+        if cfg.positional_embedding_type == "shortformer":
+            if fold_ln:
+                logging.warning("You tried to specify fold_ln=True for a shortformer model, but this can't be done! Setting fold_ln=False instead.")
+                fold_ln = False
+            if center_unembed:
+                logging.warning("You tried to specify center_unembed=True for a shortformer model, but this can't be done! Setting center_unembed=False instead.")
+                center_unembed = False
+            if center_writing_weights:
+                logging.warning("You tried to specify center_writing_weights=True for a shortformer model, but this can't be done! Setting center_writing_weights=False instead.")
+                center_writing_weights = False
+
 
         # Get the state dict of the model (ie a mapping of parameter names to tensors), processed to match the HookedTransformer parameter names.
         state_dict = loading.get_pretrained_state_dict(

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -749,6 +749,10 @@ class HookedTransformer(HookedRootModule):
             n_devices=n_devices,
         )
 
+        if cfg.positional_embedding_type == "shortformer" and fold_ln:
+            logging.warning("You tried to specify fold_ln=True for a shortformer model, but this can't be done! Setting fold_ln=False instead.")
+            fold_ln = False
+
         # Get the state dict of the model (ie a mapping of parameter names to tensors), processed to match the HookedTransformer parameter names.
         state_dict = loading.get_pretrained_state_dict(
             official_model_name, cfg, hf_model
@@ -847,12 +851,6 @@ class HookedTransformer(HookedRootModule):
         assert (
             self.cfg.n_devices == 1 or move_state_dict_to_device
         ), "If n_devices > 1, move_state_dict_to_device must be True"
-
-        
-        if self.cfg.positional_embedding_type == "shortformer":
-            if fold_ln:
-                logging.warning("You tried to specify fold_ln=True for a shortformer model, but this can't be done! Setting fold_ln=False instead.")
-                fold_ln = False
 
         if move_state_dict_to_device:
             for k, v in state_dict.items():

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -699,6 +699,10 @@ def get_pretrained_model_config(
     # Don't need to initialize weights, we're loading from pretrained
     cfg_dict["init_weights"] = False
 
+    if "positional_embedding_type" in cfg_dict and cfg_dict["positional_embedding_type"] == "shortformer" and fold_ln:
+        logging.warning("You tried to specify fold_ln=True for a shortformer model, but this can't be done! Setting fold_ln=False instead.")
+        fold_ln = False
+
     if device is not None:
         cfg_dict["device"] = device
     if fold_ln:


### PR DESCRIPTION
# Description

Currently it is not possible to load `redwood_attn_2l` with `from_pretrained` because the `fold_ln` parameter needs to be rewritten to `False` in two places, and it is only rewritten in one place. Similarly, centering weights needs to be handled properly. 

Regarding the checklist, I think the warnings describe what is happening, but lmk if this is not clear.

Fixes [# (issue)](https://github.com/neelnanda-io/TransformerLens/issues/267)

## Type of change

Please delete options that are not relevant.

- [ x  ] Bug fix (non-breaking change which fixes an issue)
- [ x  ] New feature (non-breaking change which adds functionality)

# Checklist:

- [   ] I have commented my code, particularly in hard-to-understand areas
- [   ] I have made corresponding changes to the documentation
- [   ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility