### PR TITLE
Baidicoot main - Implemented functionality for loading mingpt-style models off HF (e.g. othello-gpt)  

### DIFF
--- a/tests/acceptance/test_transformer_lens.py
+++ b/tests/acceptance/test_transformer_lens.py
@@ -36,11 +36,11 @@ loss_store = {
     "redwood_attn_2l": 10.530948638916016,
     "solu-1l": 5.256411552429199,
 }
-no_processing = {
-    "solu-1l": loss_store["solu-1l"],
-    "redwood_attn_2l": loss_store["redwood_attn_2l"],
-}
 
+no_processing = [
+    ("solu-1l", 5.256411552429199),
+    ("redwood_attn_2l",10.530948638916016),  # TODO can't be loaded with from_pretrained
+]
 
 @pytest.mark.parametrize("name,expected_loss", list(loss_store.items()))
 def test_model(name, expected_loss):

--- a/tests/acceptance/test_transformer_lens.py
+++ b/tests/acceptance/test_transformer_lens.py
@@ -1,4 +1,5 @@
 from jaxtyping import install_import_hook
+
 hook = install_import_hook("transformer_lens", ("typeguard", "typechecked"))
 
 import pytest
@@ -7,16 +8,9 @@ import torch
 from transformer_lens import HookedTransformer
 
 model_names = [
-    "attn-only-demo",
-    "gpt2-small",
-    "opt-125m",
-    "gpt-neo-125M",
-    "stanford-gpt2-small-a",
-    "solu-4l-old",
-    "solu-6l",
-    "attn-only-3l",
-    "pythia",
-    "gelu-2l",
+    "attn-only-demo", "gpt2-small", "opt-125m", "gpt-neo-125M",
+    "stanford-gpt2-small-a", "solu-4l-old", "solu-6l", "attn-only-3l",
+    "pythia", "gelu-2l", "othello-gpt"
 ]
 text = "Hello world!"
 """ 
@@ -42,7 +36,7 @@ loss_store = {
 }
 no_processing = [
     ("solu-1l", 5.256411552429199),
-    ("redwood_attn_2l", 10.530948638916016), # TODO can't be loaded with from_pretrained
+    ("redwood_attn_2l",10.530948638916016),  # TODO can't be loaded with from_pretrained
 ]
 
 
@@ -54,26 +48,52 @@ def test_model(name, expected_loss):
     assert (loss.item() - expected_loss) < 4e-5
 
 
+def test_othello_gpt():
+    # like test model but Othello GPT has a weird input format
+    # so we need to test it separately
+
+    model = HookedTransformer.from_pretrained("othello-gpt")
+    sample_input = torch.tensor([[
+        20, 19, 18, 10, 2, 1, 27, 3, 41, 42, 34, 12, 4, 40, 11, 29, 43, 13, 48,
+        56, 33, 39, 22, 44, 24, 5, 46, 6, 32, 36, 51, 58, 52, 60, 21, 53, 26,
+        31, 37, 9, 25, 38, 23, 50, 45, 17, 47, 28, 35, 30, 54, 16, 59, 49, 57,
+        14, 15, 55, 7
+    ]])
+    loss = model(sample_input, return_type="loss")
+    expected_loss = 1.9079375267028809
+    assert (loss.item() - expected_loss) < 4e-5
+
 @pytest.mark.parametrize("name,expected_loss", no_processing)
 def test_from_pretrained_no_processing(name, expected_loss):
     # Checks if manually overriding the boolean flags in from_pretrained
     # is equivalent to using from_pretrained_no_processing
 
     model_ref = HookedTransformer.from_pretrained_no_processing(name)
-    model_override = HookedTransformer.from_pretrained(name, fold_ln=False, center_writing_weights=False, center_unembed=False, refactor_factored_attn_matrices=False)
+    model_override = HookedTransformer.from_pretrained(
+        name,
+        fold_ln=False,
+        center_writing_weights=False,
+        center_unembed=False,
+        refactor_factored_attn_matrices=False)
     assert model_ref.cfg == model_override.cfg
 
-    if name != "redwood_attn_2l": # TODO can't be loaded with from_pretrained
+    if name != "redwood_attn_2l":  # TODO can't be loaded with from_pretrained
         # Do the converse check, i.e. check that overriding boolean flags in
         # from_pretrained_no_processing is equivalent to using from_pretrained
         model_ref = HookedTransformer.from_pretrained(name)
-        model_override = HookedTransformer.from_pretrained_no_processing(name, fold_ln=True, center_writing_weights=True, center_unembed=True, refactor_factored_attn_matrices=False)
+        model_override = HookedTransformer.from_pretrained_no_processing(
+            name,
+            fold_ln=True,
+            center_writing_weights=True,
+            center_unembed=True,
+            refactor_factored_attn_matrices=False)
         assert model_ref.cfg == model_override.cfg
 
     # also check losses
     loss = model_ref(text, return_type="loss")
     print(loss.item())
     assert (loss.item() - expected_loss) < 4e-5
+
 
 @torch.no_grad()
 def test_pos_embed_hook():
@@ -88,14 +108,13 @@ def test_pos_embed_hook():
     def remove_pos_embed(z, hook):
         z[:] = 0.0
         return z
-    
-    _ = model.run_with_hooks(
-        "Hello, world",
-        fwd_hooks=[("hook_pos_embed", remove_pos_embed)])
+
+    _ = model.run_with_hooks("Hello, world",
+                             fwd_hooks=[("hook_pos_embed", remove_pos_embed)])
 
     # Check that pos embed has not been permanently changed
     assert (model.W_pos == initial_W_pos).all()
-    
+
     def edit_pos_embed(z, hook):
         sequence_length = z.shape[1]
         z[1, :] = 0.0
@@ -105,8 +124,8 @@ def test_pos_embed_hook():
         assert (z[0, :] == initial_W_pos[:sequence_length]).all()
         return z
 
-    _ = model.run_with_hooks(
-        ["Hello, world", "Goodbye, world"],
-        fwd_hooks=[("hook_pos_embed", edit_pos_embed)])
+    _ = model.run_with_hooks(["Hello, world", "Goodbye, world"],
+                             fwd_hooks=[("hook_pos_embed", edit_pos_embed)])
+
 
 hook.uninstall()

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1319,7 +1319,7 @@ def convert_mingpt_weights(old_state_dict, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.b_V"] = v_bias
 
         W_O = old_state_dict[f"blocks.{l}.attn.proj.weight"]
-        W_O = einops.rearrange(W_O, "(i h) m->i h m", i=cfg.n_heads)
+        W_O = einops.rearrange(W_O, "m (i h)->i h m", i=cfg.n_heads)
         state_dict[f"blocks.{l}.attn.W_O"] = W_O
         state_dict[f"blocks.{l}.attn.b_O"] = old_state_dict[f"blocks.{l}.attn.proj.bias"]
 
@@ -1338,6 +1338,7 @@ def convert_mingpt_weights(old_state_dict, cfg: HookedTransformerConfig):
 
     state_dict["ln_final.w"] = old_state_dict["ln_f.weight"]
     state_dict["ln_final.b"] = old_state_dict["ln_f.bias"]
+
     return state_dict
 
 # %%

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -101,6 +101,7 @@ OFFICIAL_MODEL_NAMES = [
     "llama-13b-hf",
     "llama-30b-hf", 
     "llama-65b-hf",
+    "Baidicoot/Othello-GPT-Transformer-Lens",
 ]
 
 # Model Aliases:
@@ -404,6 +405,7 @@ MODEL_ALIASES = {
     "llama-13b-hf": ["llama-13b"],
     "llama-30b-hf": ["llama-30b"],
     "llama-65b-hf": ["llama-65b"],
+    "Baidicoot/Othello-GPT-Transformer-Lens": ["othello-gpt"],
 }
 
 # Sets a default model alias, by convention the first one in the model alias table, else the official name if it has no aliases
@@ -627,6 +629,7 @@ def convert_neel_model_config(official_model_name: str):
     """
     official_model_name = get_official_model_name(official_model_name)
     cfg_json: dict = utils.download_file_from_hf(official_model_name, "config.json")
+    cfg_arch = cfg_json.get("architecture", "neel" if "_old" not in official_model_name else "neel-solu-old")
     cfg_dict = {
         "d_model": cfg_json["d_model"],
         "n_layers": cfg_json["n_layers"],
@@ -635,13 +638,11 @@ def convert_neel_model_config(official_model_name: str):
         "n_heads": cfg_json["n_heads"],
         "n_ctx": cfg_json["n_ctx"],
         "d_vocab": cfg_json["d_vocab"],
-        "tokenizer_name": cfg_json["tokenizer_name"],
+        "tokenizer_name": cfg_json.get("tokenizer_name", None),
         "act_fn": cfg_json["act_fn"],
         "attn_only": cfg_json["attn_only"],
         "final_rms": cfg_json.get("final_rms", False),
-        "original_architecture": (
-            "neel" if "_old" not in official_model_name else "neel-solu-old"
-        ),
+        "original_architecture": cfg_arch
     }
     if "normalization" in cfg_json:
         cfg_dict["normalization_type"] = cfg_json["normalization"]
@@ -689,7 +690,7 @@ def get_pretrained_model_config(
 
     """
     official_model_name = get_official_model_name(model_name)
-    if official_model_name.startswith("NeelNanda") or official_model_name.startswith("ArthurConmy"):
+    if official_model_name.startswith("NeelNanda") or official_model_name.startswith("ArthurConmy") or official_model_name.startswith("Baidicoot"):
         cfg_dict = convert_neel_model_config(official_model_name)
     else:
         cfg_dict = convert_hf_model_config(official_model_name)
@@ -804,7 +805,7 @@ def get_pretrained_state_dict(
     these weights rather than reloading the model.
     """
     official_model_name = get_official_model_name(official_model_name)
-    if official_model_name.startswith("NeelNanda") or official_model_name.startswith("ArthurConmy"):
+    if official_model_name.startswith("NeelNanda") or official_model_name.startswith("ArthurConmy") or official_model_name.startswith("Baidicoot"):
         api = HfApi()
         repo_files = api.list_repo_files(official_model_name)
         if cfg.from_checkpoint:
@@ -816,6 +817,8 @@ def get_pretrained_state_dict(
         state_dict = utils.download_file_from_hf(official_model_name, file_name)
         if cfg.original_architecture == "neel-solu-old":
             state_dict = convert_neel_solu_old_weights(state_dict, cfg)
+        elif cfg.original_architecture == "mingpt":
+            state_dict = convert_mingpt_weights(state_dict, cfg)
         return state_dict
     else:
         if cfg.from_checkpoint:
@@ -1274,5 +1277,67 @@ def convert_neel_solu_old_weights(state_dict: dict, cfg: HookedTransformerConfig
             if "W_" in k and "W_pos" not in k:
                 new_state_dict[k] = v.transpose(-2, -1)
     return new_state_dict
+
+
+def convert_mingpt_weights(old_state_dict, cfg: HookedTransformerConfig):
+    # mingpt (https://github.com/karpathy/minGPT) is mostly similar to GPT-2,
+    # but doesn't concat the QKV matrices.
+    state_dict = {}
+
+    state_dict["embed.W_E"] = old_state_dict["tok_emb.weight"]
+    state_dict["pos_embed.W_pos"] = old_state_dict["pos_emb"].squeeze()
+
+    for l in range(cfg.n_layers):
+        state_dict[f"blocks.{l}.ln1.w"] = old_state_dict[f"blocks.{l}.ln1.weight"]
+        state_dict[f"blocks.{l}.ln1.b"] = old_state_dict[f"blocks.{l}.ln1.bias"]
+
+        W_Q = old_state_dict[f"blocks.{l}.attn.query.weight"]
+        W_K = old_state_dict[f"blocks.{l}.attn.key.weight"]
+        W_V = old_state_dict[f"blocks.{l}.attn.value.weight"]
+        W_Q = einops.rearrange(W_Q, "(i h) m->i m h", i=cfg.n_heads)
+        W_K = einops.rearrange(W_K, "(i h) m->i m h", i=cfg.n_heads)
+        W_V = einops.rearrange(W_V, "(i h) m->i m h", i=cfg.n_heads)
+        state_dict[f"blocks.{l}.attn.W_Q"] = W_Q
+        state_dict[f"blocks.{l}.attn.W_K"] = W_K
+        state_dict[f"blocks.{l}.attn.W_V"] = W_V
+
+        q_bias = einops.rearrange(
+            old_state_dict[f"blocks.{l}.attn.query.bias"],
+            "(i h)->i h", i=cfg.n_heads
+        )
+        k_bias = einops.rearrange(
+            old_state_dict[f"blocks.{l}.attn.key.bias"],
+            "(i h)->i h", i=cfg.n_heads
+        )
+        v_bias = einops.rearrange(
+            old_state_dict[f"blocks.{l}.attn.value.bias"],
+            "(i h)->i h", i=cfg.n_heads
+        )
+
+        state_dict[f"blocks.{l}.attn.b_Q"] = q_bias
+        state_dict[f"blocks.{l}.attn.b_K"] = k_bias
+        state_dict[f"blocks.{l}.attn.b_V"] = v_bias
+
+        W_O = old_state_dict[f"blocks.{l}.attn.proj.weight"]
+        W_O = einops.rearrange(W_O, "(i h) m->i h m", i=cfg.n_heads)
+        state_dict[f"blocks.{l}.attn.W_O"] = W_O
+        state_dict[f"blocks.{l}.attn.b_O"] = old_state_dict[f"blocks.{l}.attn.proj.bias"]
+
+        state_dict[f"blocks.{l}.ln2.w"] = old_state_dict[f"blocks.{l}.ln2.weight"]
+        state_dict[f"blocks.{l}.ln2.b"] = old_state_dict[f"blocks.{l}.ln2.bias"]
+
+        W_in = old_state_dict[f"blocks.{l}.mlp.0.weight"]
+        state_dict[f"blocks.{l}.mlp.W_in"] = W_in.T
+        state_dict[f"blocks.{l}.mlp.b_in"] = old_state_dict[f"blocks.{l}.mlp.0.bias"]
+
+        W_out = old_state_dict[f"blocks.{l}.mlp.2.weight"]
+        state_dict[f"blocks.{l}.mlp.W_out"] = W_out.T
+        state_dict[f"blocks.{l}.mlp.b_out"] = old_state_dict[f"blocks.{l}.mlp.2.bias"]
+    
+    state_dict[f"unembed.W_U"] = old_state_dict["head.weight"].T
+
+    state_dict["ln_final.w"] = old_state_dict["ln_f.weight"]
+    state_dict["ln_final.b"] = old_state_dict["ln_f.bias"]
+    return state_dict
 
 # %%


### PR DESCRIPTION
Description
Added load_mingpt_weights function in loading_from_pretrained, integrated with loading pipeline

Type of change
Please delete options that are not relevant.

 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 This change requires a documentation update
Issues:
Loading seems broken when loading without ln_fold=False, center_writing_weights=False, center_unembed=False; achives ~1e-12 MSE on outputs with the above config, ~1e-2 without.