### PR TITLE
Add tiny stories

### DIFF
--- a/tests/acceptance/test_hooked_transformer.py
+++ b/tests/acceptance/test_hooked_transformer.py
@@ -15,7 +15,7 @@ model_names = [
     "pythia",
     "gelu-2l",
     "othello-gpt",
-    "tiny-stories-33M"
+    "tiny-stories-33M",
 ]
 text = "Hello world!"
 """ 
@@ -40,7 +40,7 @@ loss_store = {
     "gelu-2l": 6.501802444458008,
     "redwood_attn_2l": 10.530948638916016,
     "solu-1l": 5.256411552429199,
-    "tiny-stories-33M": 12.203617095947266
+    "tiny-stories-33M": 12.203617095947266,
 }
 
 no_processing = [

--- a/tests/acceptance/test_hooked_transformer.py
+++ b/tests/acceptance/test_hooked_transformer.py
@@ -1,7 +1,11 @@
+import gc
+import os
+
 import pytest
 import torch
 
 from transformer_lens import HookedTransformer
+from transformer_lens.utils import clear_huggingface_cache
 
 model_names = [
     "attn-only-demo",
@@ -58,6 +62,11 @@ def test_model(name, expected_loss):
     model = HookedTransformer.from_pretrained(name)
     loss = model(text, return_type="loss")
     assert (loss.item() - expected_loss) < 4e-5
+    del model
+    gc.collect()
+
+    if "GITHUB_ACTIONS" in os.environ:
+        clear_huggingface_cache()
 
 
 def test_othello_gpt():
@@ -87,6 +96,9 @@ def test_from_pretrained_no_processing(name, expected_loss):
     # is equivalent to using from_pretrained_no_processing
 
     model_ref = HookedTransformer.from_pretrained_no_processing(name)
+    model_ref_config = model_ref.cfg
+    reff_loss = model_ref(text, return_type="loss")
+    del model_ref
     model_override = HookedTransformer.from_pretrained(
         name,
         fold_ln=False,
@@ -94,12 +106,15 @@ def test_from_pretrained_no_processing(name, expected_loss):
         center_unembed=False,
         refactor_factored_attn_matrices=False,
     )
-    assert model_ref.cfg == model_override.cfg
+    assert model_ref_config == model_override.cfg
 
     if name != "redwood_attn_2l":  # TODO can't be loaded with from_pretrained
         # Do the converse check, i.e. check that overriding boolean flags in
         # from_pretrained_no_processing is equivalent to using from_pretrained
         model_ref = HookedTransformer.from_pretrained(name)
+        model_ref_config = model_ref.cfg
+        reff_loss = model_ref(text, return_type="loss")
+        del model_ref
         model_override = HookedTransformer.from_pretrained_no_processing(
             name,
             fold_ln=True,
@@ -107,12 +122,11 @@ def test_from_pretrained_no_processing(name, expected_loss):
             center_unembed=True,
             refactor_factored_attn_matrices=False,
         )
-        assert model_ref.cfg == model_override.cfg
+        assert model_ref_config == model_override.cfg
 
     # also check losses
-    loss = model_ref(text, return_type="loss")
-    print(loss.item())
-    assert (loss.item() - expected_loss) < 4e-5
+    print(reff_loss.item())
+    assert (reff_loss.item() - expected_loss) < 4e-5
 
 
 @torch.no_grad()

--- a/tests/acceptance/test_hooked_transformer.py
+++ b/tests/acceptance/test_hooked_transformer.py
@@ -15,6 +15,7 @@ model_names = [
     "pythia",
     "gelu-2l",
     "othello-gpt",
+    "tiny-stories-33M"
 ]
 text = "Hello world!"
 """ 
@@ -39,6 +40,7 @@ loss_store = {
     "gelu-2l": 6.501802444458008,
     "redwood_attn_2l": 10.530948638916016,
     "solu-1l": 5.256411552429199,
+    "tiny-stories-33M": 12.203617095947266
 }
 
 no_processing = [

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -117,7 +117,7 @@ OFFICIAL_MODEL_NAMES = [
     "roneneldan/TinyStories-Instruct-33M",
     "roneneldan/TinyStories-1Layer-28M",
     "roneneldan/TinyStories-2Layers-33M",
-    "roneneldan/TinyStories-Instruct-1Layers-283M",
+    "roneneldan/TinyStories-Instruct-1Layers-28M",
     "roneneldan/TinyStories-Instruct-2Layers-33M",
 ]
 

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -105,6 +105,20 @@ OFFICIAL_MODEL_NAMES = [
     "llama-65b-hf",
     "Baidicoot/Othello-GPT-Transformer-Lens",
     "bert-base-cased",
+    "roneneldan/TinyStories-1M",
+    "roneneldan/TinyStories-3M",
+    "roneneldan/TinyStories-8M",
+    "roneneldan/TinyStories-28M",
+    "roneneldan/TinyStories-33M",
+    "roneneldan/TinyStories-Instruct-1M",
+    "roneneldan/TinyStories-Instruct-3M",
+    "roneneldan/TinyStories-Instruct-8M",
+    "roneneldan/TinyStories-Instruct-28M",
+    "roneneldan/TinyStories-Instruct-33M",
+    "roneneldan/TinyStories-1Layer-28M",
+    "roneneldan/TinyStories-2Layers-33M",
+    "roneneldan/TinyStories-Instruct-1Layers-283M",
+    "roneneldan/TinyStories-Instruct-2Layers-33M",
 ]
 
 # Model Aliases:
@@ -406,6 +420,20 @@ MODEL_ALIASES = {
     "llama-30b-hf": ["llama-30b"],
     "llama-65b-hf": ["llama-65b"],
     "Baidicoot/Othello-GPT-Transformer-Lens": ["othello-gpt"],
+    "roneneldan/TinyStories-1M": ["tiny-stories-1M"],
+    "roneneldan/TinyStories-3M": ["tiny-stories-3M"],
+    "roneneldan/TinyStories-8M": ["tiny-stories-8M"],
+    "roneneldan/TinyStories-28M": ["tiny-stories-28M"],
+    "roneneldan/TinyStories-33M": ["tiny-stories-33M"],
+    "roneneldan/TinyStories-Instruct-1M": ["tiny-stories-instruct-1M"],
+    "roneneldan/TinyStories-Instruct-3M": ["tiny-stories-instruct-3M"],
+    "roneneldan/TinyStories-Instruct-8M": ["tiny-stories-instruct-8M"],
+    "roneneldan/TinyStories-Instruct-28M": ["tiny-stories-instruct-28M"],
+    "roneneldan/TinyStories-Instruct-33M": ["tiny-stories-instruct-33M"],
+    "roneneldan/TinyStories-1Layer-28M": ["tiny-stories-1L-28M"],
+    "roneneldan/TinyStories-2Layers-33M": ["tiny-stories-2L-33M"],
+    "roneneldan/TinyStories-Instruct-1Layers-28M": ["tiny-stories-instruct-1L-28M"],
+    "roneneldan/TinyStories-Instruct-2Layers-33M": ["tiny-stories-instruct-2L-33M"],
 }
 
 # Sets a default model alias, by convention the first one in the model alias table, else the official name if it has no aliases

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shutil
 from typing import Dict, List, Optional, Tuple, Type, Union, cast
 
 import einops
@@ -44,6 +45,22 @@ def download_file_from_hf(
     else:
         print("File type not supported:", file_path.split(".")[-1])
         return file_path
+
+
+def clear_huggingface_cache():
+    """
+    Deletes the Hugging Face cache directory and all its contents.
+
+    This function deletes the Hugging Face cache directory, which is used to store downloaded models and their associated files. Deleting the cache directory will remove all the downloaded models and their files, so you will need to download them again if you want to use them in your code.
+
+    Parameters:
+    None
+
+    Returns:
+    None
+    """
+    print("Deleting Hugging Face cache directory and all its contents.")
+    shutil.rmtree(CACHE_DIR)
 
 
 def print_gpu_mem(step_name=""):


### PR DESCRIPTION
# Description

Closes #289 by adding the [various tiny-stories models](https://huggingface.co/datasets/roneneldan/TinyStories) from Hugginface to TransformerLens.
Also extends the hooked transformer acceptence test to check that our 33M version generates output similar to the Hugginface output that can be generated with [this](https://pastebin.com/md4E3Gru) snippet.