### PR TITLE
Add better `__name__` annotation to `full_hook`s

### DIFF
--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -61,6 +61,10 @@ class HookPoint(nn.Module):
             def full_hook(module, module_input, module_output):
                 return hook(module_output, hook=self)
 
+            full_hook.__name__ = (
+                hook.__repr__()
+            )  # annotate the `full_hook` with the string representation of the `hook` function
+
             handle = self.register_forward_hook(full_hook)
             handle = LensHandle(handle, is_permanent, level)
             self.fwd_hooks.append(handle)
@@ -68,6 +72,10 @@ class HookPoint(nn.Module):
             # For a backwards hook, module_output is a tuple of (grad,) - I don't know why.
             def full_hook(module, module_input, module_output):
                 return hook(module_output[0], hook=self)
+
+            full_hook.__name__ = (
+                hook.__repr__()
+            )  # annotate the `full_hook` with the string representation of the `hook` function
 
             handle = self.register_full_backward_hook(full_hook)
             handle = LensHandle(handle, is_permanent, level)


### PR DESCRIPTION
# Description

This adds a better `__name__` attribute to `full_hook`s that can make debugging easier.

Makes progress on https://github.com/neelnanda-io/TransformerLens/issues/297 - the snippet at the bottom there is the best example of how this may help

## Type of change

Please delete options that are not relevant.
- [ x ] New feature (non-breaking change which adds functionality)

### Screenshots
N/A

# Checklist:

- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

i) there are existing failing tests
ii) *my new changes* pass black and mypy locally 