### PR TITLE
Add prepend option to `model.add_hook`

### DIFF
--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1,6 +1,7 @@
 import pytest
-from transformer_lens import HookedTransformer
 import torch
+
+from transformer_lens import HookedTransformer
 
 MODEL = "solu-1l"
 

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -21,7 +21,7 @@ class Counter:
 def test_hook_attaches_normally():
     c = Counter()
     _ = model.run_with_hooks(prompt, fwd_hooks=[(embed, c.inc)])
-    assert all([len(hp.fwd_hooks) == 0 for _, hp in model.hook_dict.items()]) 
+    assert all([len(hp.fwd_hooks) == 0 for _, hp in model.hook_dict.items()])
     assert c.count == 1
     model.remove_all_hook_fns(including_permanent=True)
 

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -168,7 +168,13 @@ class HookedTransformer(HookedRootModule):
         self.setup()
 
     def check_hooks_to_add(
-        self, hook_point, hook_point_name, hook, dir="fwd", is_permanent=False
+        self,
+        hook_point,
+        hook_point_name,
+        hook,
+        dir="fwd",
+        is_permanent=False,
+        prepend=False,
     ) -> None:
         if hook_point_name.endswith("attn.hook_result"):
             assert (


### PR DESCRIPTION
# Description

This PR allows users to prepend hooks before all other hooks, and a test of this.

This is implemented in the same way that PyTorch 2.0 does this: search https://github.com/pytorch/pytorch/blob/bf52d570d9be0167501cd6a206b7e262e6d3860c/torch/nn/modules/module.py for "prepend"

I have checked that the test and black pass locally. I think that the main failures are not related.

## Type of change

- [ x ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility