### PR TITLE
Fix bug: HookedEncoder not being moved to GPU

### DIFF
--- a/tests/acceptance/test_hooked_encoder.py
+++ b/tests/acceptance/test_hooked_encoder.py
@@ -14,7 +14,7 @@ MODEL_NAME = "bert-base-cased"
 
 @pytest.fixture(scope="module")
 def our_bert():
-    return HookedEncoder.from_pretrained(MODEL_NAME)
+    return HookedEncoder.from_pretrained(MODEL_NAME, device="cpu")
 
 
 @pytest.fixture(scope="module")
@@ -174,3 +174,11 @@ def test_predictions(our_bert, huggingface_bert, tokenizer):
     huggingface_prediction = get_predictions(huggingface_bert_out, [2])
 
     assert our_prediction == huggingface_prediction
+
+
+@pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Requires a CUDA device"
+)
+def test_cuda(hello_world_tokens):
+    model = HookedEncoder.from_pretrained(MODEL_NAME)
+    model(hello_world_tokens)

--- a/tests/acceptance/test_hooked_encoder.py
+++ b/tests/acceptance/test_hooked_encoder.py
@@ -176,9 +176,7 @@ def test_predictions(our_bert, huggingface_bert, tokenizer):
     assert our_prediction == huggingface_prediction
 
 
-@pytest.mark.skipif(
-        not torch.cuda.is_available(), reason="Requires a CUDA device"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires a CUDA device")
 def test_cuda(hello_world_tokens):
     model = HookedEncoder.from_pretrained(MODEL_NAME)
     model(hello_world_tokens)

--- a/transformer_lens/HookedEncoder.py
+++ b/transformer_lens/HookedEncoder.py
@@ -45,9 +45,6 @@ class HookedEncoder(HookedRootModule):
         assert (
             self.cfg.n_devices == 1
         ), "Multiple devices not supported for HookedEncoder"
-        if move_to_device:
-            self.to(self.cfg.device)
-
         if tokenizer is not None:
             self.tokenizer = tokenizer
         elif self.cfg.tokenizer_name is not None:
@@ -72,6 +69,9 @@ class HookedEncoder(HookedRootModule):
         self.unembed = Unembed(self.cfg)
 
         self.hook_full_embed = HookPoint()
+
+        if move_to_device:
+            self.to(self.cfg.device)
 
         self.setup()
 


### PR DESCRIPTION
# Description
## Changes
- Move `self.to(device)` later in the file, after parameters have been initialised
- Move majority of tests to the CPU, and add a specific test for the GPU

Fixes #306 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->