### PR TITLE
Ignore some functions in the documentation (#310)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ If you are modifying a non-environment page or an atari environment page, please
 
 Install the required packages:
 
-Need to use python 3.9 (3.10 has an issue with napoleon extension) and below 3.8 doesn't have sphinx suppourt.
+Need to use python 3.9 (3.10 has an issue with napoleon extension) and below 3.8 doesn't have sphinx support.
 ```
 poetry install --extras docs
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,3 +40,37 @@ html_static_path = ["_static"]
 html_logo = "_static/transformer_lens_logo.png"
 
 html_favicon = "favicon.ico"
+
+
+# -- Ignore some functions that are not interesting for end users ------------
+
+functions_to_ignore = [
+    # functions from load_from_pretrained.py
+    "convert_hf_model_config",
+    "convert_bert_weights",
+    "convert_gpt2_weights",
+    "convert_gptj_weights",
+    "convert_llama_weights",
+    "convert_mingpt_weights",
+    "convert_neel_solu_old_weights",
+    "convert_neo_weights",
+    "convert_neox_weights",
+    "convert_neel_model_config",
+    "convert_opt_weights",
+    "fill_missing_keys",
+    "get_basic_config",
+    "get_official_model_name",
+    "get_pretrained_state_dict",
+    "make_model_alias_map",
+    # functions from make_docs.py
+    "get_config",
+    "get_property",
+    # functions from patching.py
+    "make_df_from_ranges",
+    # functions from utils.py
+    "check_structure",
+    "clear_huggingface_cache",
+    "select_compatible_kwargs",
+]
+
+autodoc_default_options = {'exclude-members': ", ".join(functions_to_ignore)}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,4 +73,4 @@ functions_to_ignore = [
     "select_compatible_kwargs",
 ]
 
-autodoc_default_options = {'exclude-members': ", ".join(functions_to_ignore)}
+autodoc_default_options = {"exclude-members": ", ".join(functions_to_ignore)}

--- a/docs/source/transformer_lens.rst
+++ b/docs/source/transformer_lens.rst
@@ -1,6 +1,14 @@
 transformer\_lens package
 =========================
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   transformer_lens.utilities
+
 Submodules
 ----------
 
@@ -16,6 +24,14 @@ transformer\_lens.FactoredMatrix module
 ---------------------------------------
 
 .. automodule:: transformer_lens.FactoredMatrix
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+transformer\_lens.HookedEncoder module
+--------------------------------------
+
+.. automodule:: transformer_lens.HookedEncoder
    :members:
    :undoc-members:
    :show-inheritance:
@@ -48,6 +64,14 @@ transformer\_lens.evals module
 ------------------------------
 
 .. automodule:: transformer_lens.evals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+transformer\_lens.head\_detector module
+---------------------------------------
+
+.. automodule:: transformer_lens.head_detector
    :members:
    :undoc-members:
    :show-inheritance:
@@ -88,14 +112,6 @@ transformer\_lens.patching module
 ---------------------------------
 
 .. automodule:: transformer_lens.patching
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-transformer\_lens.torchtyping\_helper module
---------------------------------------------
-
-.. automodule:: transformer_lens.torchtyping_helper
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/transformer_lens.utilities.rst
+++ b/docs/source/transformer_lens.utilities.rst
@@ -1,0 +1,21 @@
+transformer\_lens.utilities package
+===================================
+
+Submodules
+----------
+
+transformer\_lens.utilities.devices module
+------------------------------------------
+
+.. automodule:: transformer_lens.utilities.devices
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: transformer_lens.utilities
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/unit/test_head_detector.py
+++ b/tests/unit/test_head_detector.py
@@ -14,8 +14,6 @@ from transformer_lens.head_detector import (
     get_previous_token_head_detection_pattern,
 )
 
-# from transformer_lens.utils import check_structure as check
-
 MODEL = "solu-2l"
 ATOL = 1e-4  # Absolute tolerance - how far does a float have to be before we consider it no longer equal?
 # ATOL is set to 1e-4 because the tensors we check on are also to 4 decimal places.

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -845,7 +845,7 @@ def get_checkpoint_labels(model_name: str, **kwargs):
         api = HfApi()
         files_list = api.list_repo_files(
             official_model_name,
-            **utils._select_compatible_kwargs(kwargs, api.list_repo_files),
+            **utils.select_compatible_kwargs(kwargs, api.list_repo_files),
         )
         labels = []
         for file_name in files_list:
@@ -889,7 +889,7 @@ def get_pretrained_state_dict(
         api = HfApi()
         repo_files = api.list_repo_files(
             official_model_name,
-            **utils._select_compatible_kwargs(kwargs, api.list_repo_files),
+            **utils.select_compatible_kwargs(kwargs, api.list_repo_files),
         )
         if cfg.from_checkpoint:
             file_name = list(

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -24,7 +24,7 @@ import json
 from jaxtyping import Float, Int
 
 
-def _select_compatible_kwargs(
+def select_compatible_kwargs(
     kwargs_dict: Dict[str, Any], callable: Callable
 ) -> Dict[str, Any]:
     """Return a dict with the elements kwargs_dict that are parameters of callable"""
@@ -53,7 +53,7 @@ def download_file_from_hf(
         filename=file_name,
         subfolder=subfolder,
         cache_dir=cache_dir,
-        **_select_compatible_kwargs(kwargs, hf_hub_download),
+        **select_compatible_kwargs(kwargs, hf_hub_download),
     )
 
     # Load to the CPU device if CUDA is not available


### PR DESCRIPTION
# Description

The aim is to ignore in the documentation some functions that are not useful for end users, to reduce the quantity of superfluous information. At first I was proposing to add an underscore (e.g. `make_model_alias_map` => `_make_model_alias_map`), but I finally adopted the safer approach proposed by @ArthurConmy of using the `field exclude-members` in `autodoc_default_options` to specify functions to ignore. It is then indeed not displayed in Sphinx.

I reverted one of the modifications of my last PR (`_select_compatible_kwargs` => `select_compatible_kwargs`) to be consistent everywhere.

The list of functions to ignore is debatable. I didn't add any class method (although `fill_missing_keys` is a function in `loading_from_pretrained.py`, but also a method of `HookedTransformer` which is then ignored as well)

Fixes #310 

## Type of change
Documentation update