### PR TITLE
Add `hook_mlp_in`

### DIFF
--- a/tests/acceptance/test_activation_cache.py
+++ b/tests/acceptance/test_activation_cache.py
@@ -289,3 +289,18 @@ def test_stack_neuron_results_with_apply_ln():
     assert torch.isclose(
         ref_scaled_residual_stack, scaled_residual_stack, atol=1e-7
     ).all()
+
+
+def test_hook_mlp_in_memory():
+    """Test that the new hook_mlp_in is not taking any extra memory"""
+
+    model = load_model("solu-2l")
+
+    # Run the model and cache all activations
+    tokens, _ = get_ioi_tokens_and_answer_tokens(model)
+    _, cache = model.run_with_cache(tokens)
+
+    assert (
+        cache["blocks.0.hook_resid_mid"].data_ptr()
+        == cache["blocks.0.hook_mlp_in"].data_ptr()
+    )

--- a/tests/unit/test_cache_hook_names.py
+++ b/tests/unit/test_cache_hook_names.py
@@ -19,6 +19,7 @@ act_names_in_cache = [
     "blocks.0.attn.hook_z",
     "blocks.0.hook_attn_out",
     "blocks.0.hook_resid_mid",
+    "blocks.0.hook_mlp_in",
     "blocks.0.ln2.hook_scale",
     "blocks.0.ln2.hook_normalized",
     "blocks.0.mlp.hook_pre",

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1334,14 +1334,14 @@ class HookedTransformer(HookedRootModule):
 
         return state_dict
 
-    def set_use_attn_result(self, use_attn_result):
+    def set_use_attn_result(self, use_attn_result: bool):
         """
         Toggles whether to explicitly calculate and expose the result for each attention head - useful for
         interpretability but can easily burn through GPU memory.
         """
         self.cfg.use_attn_result = use_attn_result
 
-    def set_use_split_qkv_input(self, use_split_qkv_input):
+    def set_use_split_qkv_input(self, use_split_qkv_input: bool):
         """
         Toggles whether to allow editing of inputs to each attention head.
         """

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -864,6 +864,8 @@ class TransformerBlock(nn.Module):
         self.hook_v_input = HookPoint()  # [batch, pos, d_model]
 
         self.hook_attn_out = HookPoint()  # [batch, pos, d_model]
+
+        self.hook_mlp_in = HookPoint()  # [batch, pos, d_model]
         self.hook_mlp_out = HookPoint()  # [batch, pos, d_model]
         self.hook_resid_pre = HookPoint()  # [batch, pos, d_model]
         if not self.cfg.attn_only and not self.cfg.parallel_attn_mlp:
@@ -927,7 +929,7 @@ class TransformerBlock(nn.Module):
             resid_mid = self.hook_resid_mid(
                 resid_pre + attn_out
             )  # [batch, pos, d_model]
-            normalized_resid_mid = self.ln2(resid_mid)
+            normalized_resid_mid = self.ln2(self.hook_mlp_in(resid_mid))
             mlp_out = self.hook_mlp_out(
                 self.mlp(normalized_resid_mid)
             )  # [batch, pos, d_model]
@@ -970,6 +972,7 @@ class BertBlock(nn.Module):
         self.hook_v_input = HookPoint()  # [batch, pos, d_model]
 
         self.hook_attn_out = HookPoint()  # [batch, pos, d_model]
+        self.hook_mlp_in = HookPoint()  # [batch, pos, d_model]
         self.hook_mlp_out = HookPoint()  # [batch, pos, d_model]
         self.hook_resid_pre = HookPoint()  # [batch, pos, d_model]
         self.hook_resid_mid = HookPoint()  # [batch, pos, d_model]
@@ -1011,7 +1014,7 @@ class BertBlock(nn.Module):
         resid_mid = self.hook_resid_mid(resid_pre + attn_out)
         normalized_resid_mid = self.ln1(resid_mid)
 
-        mlp_out = self.hook_mlp_out(self.mlp(normalized_resid_mid))
+        mlp_out = self.hook_mlp_out(self.mlp(self.hook_mlp_in(normalized_resid_mid)))
         resid_post = self.hook_resid_post(normalized_resid_mid + mlp_out)
         normalized_resid_post = self.hook_normalized_resid_post(self.ln2(resid_post))
 


### PR DESCRIPTION
# Problem

Currently, there's no clean way to manipulate the output of one attention head into a future MLP in our transformer model. This is because editing hook_resid_mid affects the residual stream beyond the MLP too, as it is used in the computation of both resid_mid and resid_post.

# Solution

This PR introduces a new `hook_mlp_in` `HookPoint` that allows modification of the input to an MLP. 

It adds a test too. I also commented two places I found some repeated code, I'm happy to improve this too if wanted.

# Details

This HookPoint will be enabled by default. Initially, we were concerned about potential memory bloat and potential backwards compatibility issues with old code that expects a specific set of keys in an ActivationCache. However, upon further investigation, it was found that since the resid_mid and hook_mlp_in(resid_mid) share the same underlying storage, there is no memory bloat. 

As for backwards compatibility, the addition of a new key to the ActivationCache could break any existing code that does not specifically rely on the absence of this key, but we expect this to be unlikely.

Closes https://github.com/neelnanda-io/TransformerLens/issues/309

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility