### PR TITLE
Support for reduced precision (#104)

### DIFF
--- a/tests/acceptance/test_hooked_encoder.py
+++ b/tests/acceptance/test_hooked_encoder.py
@@ -136,16 +136,6 @@ def test_run_with_cache(our_bert, huggingface_bert, hello_world_tokens):
     assert "mlm_head.ln.hook_normalized" in cache
 
 
-@pytest.mark.skipif(
-    torch.backends.mps.is_available(),
-    reason="bfloat16 unsupported by MPS: https://github.com/pytorch/pytorch/issues/78168",
-)
-def test_from_pretrained_dtype():
-    """Check that the parameter `torch_dtype` works"""
-    model = HookedEncoder.from_pretrained(MODEL_NAME, torch_dtype=torch.bfloat16)
-    assert model.W_K.dtype == torch.bfloat16
-
-
 def test_from_pretrained_revision():
     """
     Check that the from_pretrained parameter `revision` (= git version) works
@@ -159,6 +149,19 @@ def test_from_pretrained_revision():
         pass
     else:
         raise AssertionError("Should have raised an error")
+
+
+@pytest.mark.skipif(
+    torch.backends.mps.is_available() or not torch.cuda.is_available(),
+    reason="bfloat16 unsupported by MPS: https://github.com/pytorch/pytorch/issues/78168 or no GPU",
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_half_precision(dtype):
+    """Check the 16 bits loading and inferences."""
+    model = HookedEncoder.from_pretrained(MODEL_NAME, torch_dtype=dtype)
+    assert model.W_K.dtype == dtype
+
+    _ = model(model.tokenizer("Hello, world", return_tensors="pt")["input_ids"])
 
 
 def test_predictions(our_bert, huggingface_bert, tokenizer):

--- a/tests/acceptance/test_hooked_transformer.py
+++ b/tests/acceptance/test_hooked_transformer.py
@@ -182,7 +182,9 @@ def check_performance(tl_model, hf_model, margin):
     approximately the same confidence in the expected answer.
     """
     prompt = " Unable"
-    tokens = tl_model.tokenizer(prompt, return_tensors="pt")["input_ids"].to("cuda" if torch.cuda.is_available() else "cpu")
+    tokens = tl_model.tokenizer(prompt, return_tensors="pt")["input_ids"].to(
+        "cuda" if torch.cuda.is_available() else "cpu"
+    )
 
     expected_token = tl_model.tokenizer.encode(" to")[
         0
@@ -200,7 +202,9 @@ def check_dtype(dtype, margin, no_processing=False):
     for model_path in ["gpt2", "roneneldan/TinyStories-33M", "EleutherAI/pythia-70m"]:
         if no_processing:
             # For low precision, the processing is not advised.
-            model = HookedTransformer.from_pretrained_no_processing(model_path, torch_dtype=dtype)
+            model = HookedTransformer.from_pretrained_no_processing(
+                model_path, torch_dtype=dtype
+            )
         else:
             model = HookedTransformer.from_pretrained(model_path, torch_dtype=dtype)
 

--- a/tests/acceptance/test_hooked_transformer.py
+++ b/tests/acceptance/test_hooked_transformer.py
@@ -176,13 +176,13 @@ def check_similarity_with_hf_model(tl_model, hf_model, prompt="Hello, world!"):
     )
 
 
-def check_performance(tl_model, hf_model, margin=0.01):
+def check_performance(tl_model, hf_model, margin):
     """
     Check that the TransformerLens model and the HuggingFace have
     approximately the same confidence in the expected answer.
     """
     prompt = " Unable"
-    tokens = tl_model.tokenizer(prompt, return_tensors="pt")["input_ids"]
+    tokens = tl_model.tokenizer(prompt, return_tensors="pt")["input_ids"].to("cuda" if torch.cuda.is_available() else "cpu")
 
     expected_token = tl_model.tokenizer.encode(" to")[
         0
@@ -195,10 +195,15 @@ def check_performance(tl_model, hf_model, margin=0.01):
     assert tl_prob + margin > hf_prob
 
 
-def check_dtype(dtype, margin=0.01):
+def check_dtype(dtype, margin, no_processing=False):
     """Check the loading and inferences for different dtypes."""
     for model_path in ["gpt2", "roneneldan/TinyStories-33M", "EleutherAI/pythia-70m"]:
-        model = HookedTransformer.from_pretrained(model_path, torch_dtype=dtype)
+        if no_processing:
+            # For low precision, the processing is not advised.
+            model = HookedTransformer.from_pretrained_no_processing(model_path, torch_dtype=dtype)
+        else:
+            model = HookedTransformer.from_pretrained(model_path, torch_dtype=dtype)
+
         hf_model = AutoModelForCausalLM.from_pretrained(
             model_path,
             torch_dtype=dtype,
@@ -233,7 +238,7 @@ def test_half_precision(dtype):
     and some float16 operations require having a GPU.
     bfloat16 can be used without GPU, but surprisingly it doesn't give the same results in this case.
     """
-    check_dtype(dtype, margin=0.005)
+    check_dtype(dtype, margin=0.05, no_processing=True)
 
 
 @torch.no_grad()

--- a/transformer_lens/HookedEncoder.py
+++ b/transformer_lens/HookedEncoder.py
@@ -217,6 +217,11 @@ class HookedEncoder(HookedRootModule):
             "that the last LayerNorm in a block cannot be folded."
         )
 
+        assert not (
+            from_pretrained_kwargs.get("load_in_8bit", False)
+            or from_pretrained_kwargs.get("load_in_4bit", False)
+        ), "Quantization not supported"
+
         official_model_name = loading.get_official_model_name(model_name)
 
         cfg = loading.get_pretrained_model_config(
@@ -234,10 +239,6 @@ class HookedEncoder(HookedRootModule):
         )
 
         model = cls(cfg, tokenizer, move_to_device=False)
-
-        dtype = from_pretrained_kwargs.get("torch_dtype", None)
-        if dtype is not None:
-            model = model.to(dtype)
 
         model.load_state_dict(state_dict, strict=False)
 

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1030,10 +1030,11 @@ class HookedTransformer(HookedRootModule):
             model_name (str, optional): checks the model name for special cases of state dict loading. Only used for
                 Redwood 2L model currently
         """
-        if self.cfg.dtype not in [torch.float32, torch.float64]:
+        if self.cfg.dtype not in [torch.float32, torch.float64] and fold_ln:
             logging.warning(
                 "With reduced precision, it is advised to use `from_pretrained_no_processing` instead of `from_pretrained`."
             )
+
         state_dict = self.fill_missing_keys(state_dict)
         if fold_ln:
             if self.cfg.normalization_type not in ["LN", "LNPre"]:

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -875,8 +875,12 @@ class HookedTransformer(HookedRootModule):
             or from_pretrained_kwargs.get("load_in_4bit", False)
         ), "Quantization not supported"
 
-        if from_pretrained_kwargs.get("torch_dtype", None) == torch.float16 and device in ["cpu", None]:
-            logging.warning("float16 models may not work on CPU. Consider using a GPU or bfloat16.")
+        if from_pretrained_kwargs.get(
+            "torch_dtype", None
+        ) == torch.float16 and device in ["cpu", None]:
+            logging.warning(
+                "float16 models may not work on CPU. Consider using a GPU or bfloat16."
+            )
 
         # Get the model name used in HuggingFace, rather than the alias.
         official_model_name = loading.get_official_model_name(model_name)

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -134,6 +134,7 @@ class HookedTransformerConfig:
             trained with this, heads often use the first position as a resting position and accordingly lose information from
             the first token, so this empirically seems to give better results. Call set_default_prepend_bos(False) to change
             this default value to False.
+        dtype (torch.dtype, *optional*): The model's dtype. Defaults to torch.float32.
     """
 
     n_layers: int
@@ -178,6 +179,7 @@ class HookedTransformerConfig:
     use_hook_tokens: bool = False
     gated_mlp: bool = False
     default_prepend_bos: bool = True
+    dtype: torch.dtype = torch.float32
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/head_detector.py
+++ b/transformer_lens/head_detector.py
@@ -144,7 +144,7 @@ def detect_head(
     else:
         layer2heads = heads
 
-    matches = -torch.ones(cfg.n_layers, cfg.n_heads)
+    matches = -torch.ones(cfg.n_layers, cfg.n_heads, dtype=cfg.dtype)
 
     for layer, layer_heads in layer2heads.items():
         # [n_heads q_pos k_pos]

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -769,6 +769,12 @@ def get_pretrained_model_config(
 
     if device is not None:
         cfg_dict["device"] = device
+
+    if kwargs.get("torch_dtype", None) is not None:
+        cfg_dict["dtype"] = kwargs["torch_dtype"]
+    elif "dtype" in cfg_dict:
+        kwargs["torch_dtype"] = cfg_dict["dtype"]
+
     if fold_ln:
         if cfg_dict["normalization_type"] in ["LN", "LNPre"]:
             cfg_dict["normalization_type"] = "LNPre"

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1079,9 +1079,9 @@ def convert_neo_weights(neo, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.W_K"] = W_K
         state_dict[f"blocks.{l}.attn.W_V"] = W_V
 
-        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head)
-        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head)
-        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head)
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
 
         W_O = neo.transformer.h[l].attn.attention.out_proj.weight
         W_O = einops.rearrange(W_O, "m (i h)->i h m", i=cfg.n_heads)
@@ -1102,7 +1102,7 @@ def convert_neo_weights(neo, cfg: HookedTransformerConfig):
     state_dict["ln_final.b"] = neo.transformer.ln_f.bias
 
     state_dict["unembed.W_U"] = neo.lm_head.weight.T
-    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab)
+    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
     return state_dict
 
 
@@ -1125,14 +1125,14 @@ def convert_gptj_weights(gptj, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.W_K"] = W_K
         state_dict[f"blocks.{l}.attn.W_V"] = W_V
 
-        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head)
-        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head)
-        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head)
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
 
         W_O = gptj.transformer.h[l].attn.out_proj.weight
         W_O = einops.rearrange(W_O, "m (i h)->i h m", i=cfg.n_heads)
         state_dict[f"blocks.{l}.attn.W_O"] = W_O
-        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(cfg.d_model)
+        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
 
         # Layer Norm 1 and 2 are tied.
         state_dict[f"blocks.{l}.ln2.w"] = state_dict[f"blocks.{l}.ln1.w"]
@@ -1217,7 +1217,7 @@ def convert_neox_weights(neox, cfg: HookedTransformerConfig):
     state_dict["ln_final.b"] = neox.gpt_neox.final_layer_norm.bias
 
     state_dict["unembed.W_U"] = neox.embed_out.weight.T
-    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab)
+    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
     return state_dict
 
 
@@ -1242,15 +1242,15 @@ def convert_llama_weights(llama, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.W_K"] = W_K
         state_dict[f"blocks.{l}.attn.W_V"] = W_V
 
-        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head)
-        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head)
-        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head)
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
 
         W_O = llama.model.layers[l].self_attn.o_proj.weight
         W_O = einops.rearrange(W_O, "m (n h)->n h m", n=cfg.n_heads)
         state_dict[f"blocks.{l}.attn.W_O"] = W_O
 
-        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(cfg.d_model)
+        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
 
         state_dict[f"blocks.{l}.ln2.w"] = llama.model.layers[
             l
@@ -1260,17 +1260,17 @@ def convert_llama_weights(llama, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.mlp.W_gate"] = llama.model.layers[
             l
         ].mlp.gate_proj.weight.T
-        state_dict[f"blocks.{l}.mlp.b_in"] = torch.zeros(cfg.d_mlp)
+        state_dict[f"blocks.{l}.mlp.b_in"] = torch.zeros(cfg.d_mlp, dtype=cfg.dtype)
 
         state_dict[f"blocks.{l}.mlp.W_out"] = llama.model.layers[
             l
         ].mlp.down_proj.weight.T
-        state_dict[f"blocks.{l}.mlp.b_out"] = torch.zeros(cfg.d_model)
+        state_dict[f"blocks.{l}.mlp.b_out"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
 
     state_dict["ln_final.w"] = llama.model.norm.weight
 
     state_dict["unembed.W_U"] = llama.lm_head.weight.T
-    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab)
+    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
 
     return state_dict
 
@@ -1361,7 +1361,7 @@ def convert_opt_weights(opt, cfg: HookedTransformerConfig):
     state_dict["ln_final.w"] = opt.model.decoder.final_layer_norm.weight
     state_dict["ln_final.b"] = opt.model.decoder.final_layer_norm.bias
     state_dict["unembed.W_U"] = opt.lm_head.weight.T
-    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab)
+    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
     return state_dict
 
 

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1079,9 +1079,15 @@ def convert_neo_weights(neo, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.W_K"] = W_K
         state_dict[f"blocks.{l}.attn.W_V"] = W_V
 
-        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
-        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
-        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
 
         W_O = neo.transformer.h[l].attn.attention.out_proj.weight
         W_O = einops.rearrange(W_O, "m (i h)->i h m", i=cfg.n_heads)
@@ -1125,9 +1131,15 @@ def convert_gptj_weights(gptj, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.W_K"] = W_K
         state_dict[f"blocks.{l}.attn.W_V"] = W_V
 
-        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
-        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
-        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
 
         W_O = gptj.transformer.h[l].attn.out_proj.weight
         W_O = einops.rearrange(W_O, "m (i h)->i h m", i=cfg.n_heads)
@@ -1242,9 +1254,15 @@ def convert_llama_weights(llama, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.W_K"] = W_K
         state_dict[f"blocks.{l}.attn.W_V"] = W_V
 
-        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
-        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
-        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
 
         W_O = llama.model.layers[l].self_attn.o_proj.weight
         W_O = einops.rearrange(W_O, "m (n h)->n h m", n=cfg.n_heads)

--- a/transformer_lens/past_key_value_caching.py
+++ b/transformer_lens/past_key_value_caching.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Union
 
 import torch
 from jaxtyping import Float
@@ -17,15 +17,15 @@ class HookedTransformerKeyValueCacheEntry:
     def init_cache_entry(
         cls,
         cfg: HookedTransformerConfig,
-        device: torch.device,
+        device: Union[torch.device, str, None],
         batch_size: int = 1,
     ):
         return cls(
             past_keys=torch.empty(
-                (batch_size, 0, cfg.n_heads, cfg.d_head), device=device
+                (batch_size, 0, cfg.n_heads, cfg.d_head), device=device, dtype=cfg.dtype
             ),
             past_values=torch.empty(
-                (batch_size, 0, cfg.n_heads, cfg.d_head), device=device
+                (batch_size, 0, cfg.n_heads, cfg.d_head), device=device, dtype=cfg.dtype
             ),
         )
 
@@ -60,7 +60,10 @@ class HookedTransformerKeyValueCache:
 
     @classmethod
     def init_cache(
-        cls, cfg: HookedTransformerConfig, device: torch.device, batch_size: int = 1
+        cls,
+        cfg: HookedTransformerConfig,
+        device: Union[torch.device, str, None],
+        batch_size: int = 1,
     ):
         return cls(
             entries=[

--- a/transformer_lens/utilities/devices.py
+++ b/transformer_lens/utilities/devices.py
@@ -59,6 +59,7 @@ def move_to_and_update_config(
         if print_details:
             print("Moving model to device: ", model.cfg.device)
     elif isinstance(device_or_dtype, torch.dtype):
+        model.cfg.dtype = device_or_dtype
         if print_details:
             print("Changing model dtype to", device_or_dtype)
         # change state_dict dtypes

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -293,7 +293,7 @@ def sample_logits(
     temperature: float = 1.0,
     freq_penalty: float = 0.0,
     tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-) -> Float[torch.Tensor, "batch"]:
+) -> Int[torch.Tensor, "batch"]:
     """
     Sample from the logits, in order to generate text
 
@@ -459,7 +459,7 @@ class Slice:
     def indices(
         self,
         max_ctx: Optional[int] = None,
-    ) -> Union[np.ndarray, np.int64]:
+    ) -> Union[np.ndarray, np.int32, np.int64]:
         """
         Returns the indices when this slice is applied to an axis of size max_ctx. Returns them as a numpy array, for integer slicing it is eg array([4])
 

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -345,6 +345,8 @@ def sample_logits(
                 -1, sorted_indices, sorted_indices_to_remove
             )
             final_logits = final_logits.masked_fill(indices_to_remove, -float("inf"))
+
+        final_logits = final_logits.to(torch.float32)
         return torch.distributions.categorical.Categorical(logits=final_logits).sample()
 
 


### PR DESCRIPTION
# Description
`HookedTransformerKeyValueCacheEntry` wasn't compatible with other dtypes, so the argument `past_kv_cache_entry` wasn't working.
There is also an optimization. Instead of initializing the model in torch.float32 and then converting it to the desired dtype, we now directly initialize the model layers in the desired dtype.
The attribute `dtype` was added to the configuration with the default value torch.float32. I hope this is ok. It's practical to have access to it from anywhere.
Also added a test for 8 bits loading, which is skipped if there is no GPU.

Fixes # 104

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility