### PR TITLE
Set IGNORE value in mask to -torch.inf

### DIFF
--- a/transformer_lens/HookedEncoder.py
+++ b/transformer_lens/HookedEncoder.py
@@ -120,7 +120,7 @@ class HookedEncoder(HookedRootModule):
 
         resid = self.hook_full_embed(self.embed(tokens, token_type_ids))
 
-        large_negative_number = -1e5
+        large_negative_number = -torch.inf
         additive_attention_mask = (
             large_negative_number
             * repeat(1 - one_zero_attention_mask, "batch pos -> batch 1 1 pos")

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -377,6 +377,8 @@ class Attention(nn.Module):
         else:
             raise ValueError(f"Invalid attention type: {self.attn_type}")
 
+        self.register_buffer("IGNORE", torch.tensor(-torch.inf))
+
         self.layer_id = layer_id
 
         # attn_scale is a constant that we divide the attention scores by pre-softmax. I'm not entirely sure why it matters, but it's probably a mix of softmax not being scale invariant and numerical stability?
@@ -589,17 +591,13 @@ class Attention(nn.Module):
         assert (
             query_ctx_length + past_kv_pos_offset == key_ctx_length
         ), f"query_ctx_length {query_ctx_length} + past_kv_pos_offset {past_kv_pos_offset} != key_ctx_length {key_ctx_length} - you likely have a bug."
-
-        IGNORE = torch.finfo(attn_scores.dtype).min
-        IGNORE = torch.tensor(IGNORE, dtype=attn_scores.dtype).to(attn_scores.device)
-
         return torch.where(
             self.mask[
                 past_kv_pos_offset : past_kv_pos_offset + query_ctx_length,
                 :key_ctx_length,
             ],
             attn_scores,
-            IGNORE,
+            self.IGNORE,
         )
 
     def rotary_rotate_qk(


### PR DESCRIPTION
# Description

Fixes #318 - In pythia-70m, attn_scores can get below -1e5 (for some reason...). Masked attn scores are set to -1e5, so this makes the model attend outside the mask! This is dumb, and so I set things to -torch.inf instead. It's still registered as a buffer so should move to device + dtypes accordingly

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have not rewritten tests relating to key interfaces which would affect backward compatibility