### PR TITLE
Add assertion to refactor_factored_attn_matrices

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1282,9 +1282,12 @@ class HookedTransformer(HookedRootModule):
         we concatenate them to W_Q and W_K to simulate a d_model+1 dimensional
         input (whose final coordinate is always 1), do the SVD factorization on
         this effective matrix, then separate out into final weights and biases
-
-
         """
+
+        assert (
+            self.cfg.positional_embedding_type != "rotary"
+        ), "You can't refactor the QK circuit when using rotary embeddings (as the QK matrix depends on the position of the query and key)"
+
         for l in range(self.cfg.n_layers):
             # W_QK = W_Q @ W_K.T
             # Concatenate biases to make a d_model+1 input dimension


### PR DESCRIPTION
# Description

You can't `refactor_factored_attn_matrices` with rotary models so error here.

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

I don't think we need a test for this because that would require loading in a `pythia-70m` which seems an annoying increase to test speed, so this is ready for review