### PR TITLE
`names_filter` bug fix

### DIFF
--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -380,9 +380,11 @@ class HookedRootModule(nn.Module):
         if names_filter is None:
             names_filter = lambda name: True
         elif type(names_filter) == str:
-            names_filter = lambda name: name == names_filter
+            filter_str = names_filter
+            names_filter = lambda name: name == filter_str
         elif type(names_filter) == list:
-            names_filter = lambda name: name in names_filter
+            filter_list = names_filter
+            names_filter = lambda name: name in filter_list
 
         self.is_caching = True
 
@@ -486,10 +488,11 @@ class HookedRootModule(nn.Module):
         if names_filter is None:
             names_filter = lambda name: True
         elif type(names_filter) == str:
-            names_filter = lambda name: name == names_filter
+            filter_str = names_filter
+            names_filter = lambda name: name == filter_str
         elif type(names_filter) == list:
-            names_filter = lambda name: name in names_filter
-
+            filter_list = names_filter
+            names_filter = lambda name: name in filter_list
         self.is_caching = True
 
         def save_hook(tensor, hook):


### PR DESCRIPTION
These lines don't work in the intended way when `names_filter` is a string because redefining names_filter and using it in the lambda expression doesn't play nicely (CC GPT-4 or "late binding" in Python docs)

More generally I think the type for `NamesFilter` should also contain `str`s (`Sequence[str]` isn't really accurate) and the documentation of `add_caching_hooks` should mention that `names_filter` can be a string. Happy to merge this fix as-is or implement those two docs changes on top of this