### PR TITLE
Added support for left_pad to HookedTransformer

### DIFF
--- a/demos/Exploratory_Analysis_Demo.ipynb
+++ b/demos/Exploratory_Analysis_Demo.ipynb
@@ -295,10 +295,13 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "The first step is to load in our model, GPT-2 Small, a 12 layer and 80M parameter transformer with `HookedTransformer.from_pretrained`. The various flags are simplifications that preserve the model's output but simplify its internals, see [here](TODO: link) for details."
+                "The first step is to load in our model, GPT-2 Small, a 12 layer and 80M parameter transformer with `HookedTransformer.from_pretrained`. The various flags are simplifications that preserve the model's output but simplify its internals, see [here](TODO: link) for details.\n",
+                "\n",
+                "**Gotcha:** If using prompts with different lengths, pass `left_pad=True` as an argument to the `model.to_tokens()` method if you want to naively index into the final logit. (i.e, `logits[:, -1, :]`). By default, tokenizers pad on the right, so any shorter sequences will end in pad tokens, so `logits[:, -1, :]` picks up a lot of pad tokens. If padding from the left, `logits[:, -1, :]` always picks up the logits of the final token in the sequence."
             ]
         },
         {
@@ -481,14 +484,6 @@
                 "answer_tokens = torch.tensor(answer_tokens).cuda()\n",
                 "print(prompts)\n",
                 "print(answers)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "**Gotcha**: It's important that all of your prompts have the same number of tokens. If they're different lengths, then the position of the \"final\" logit where you can check logit difference will differ between prompts, and this will break the below code. The easiest solution is just to choose your prompts carefully to have the same number of tokens (you can eg add filler words like The, or newlines to start). There's a range of other ways of solving this, eg you can also index more intelligently to get the final logit"
             ]
         },
         {

--- a/tests/unit/test_tokenization_methods.py
+++ b/tests/unit/test_tokenization_methods.py
@@ -27,6 +27,13 @@ def test_set_tokenizer_lazy():
     assert model2.to_single_token(" SolidGoldMagicarp") == 15831, "glitch token"
 
 
+def test_left_pad():
+    model = HookedTransformer.from_pretrained("solu-1l", left_pad=True)
+    assert model.tokenizer.padding_side == "left"
+    tokens = model.to_tokens(["Sequence", "Longer sequence"])
+    assert torch.all(tokens == tensor([[2, 2, 1, 25232], [1, 12144, 255, 3315]]))
+
+
 def test_to_tokens_default():
     s = "Hello, world!"
     tokens = model.to_tokens(s)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -59,6 +59,7 @@ class HookedTransformer(HookedRootModule):
         self,
         cfg,
         tokenizer=None,
+        left_pad=False,
         move_to_device=True,
     ):
         """
@@ -70,6 +71,8 @@ class HookedTransformer(HookedRootModule):
         tokenizer (*optional): The tokenizer to use for the model. If not
             provided, it is inferred from cfg.tokenizer_name or initialized to None.
             If None, then the model cannot be passed strings, and d_vocab must be explicitly set.
+        left_pad (bool): Whether the tokenizer should pad from the left instead of the right.
+            False by default. If False, padding_side is set to right.
         move_to_device (bool): Whether to move the model to the device specified in cfg.
             device. Must be true if `n_devices` in the config is greater than 1, since the model's layers
             will be split across multiple devices.
@@ -83,6 +86,7 @@ class HookedTransformer(HookedRootModule):
                 "pretrained model, use HookedTransformer.from_pretrained() instead."
             )
         self.cfg = cfg
+        self.left_pad = left_pad
 
         assert (
             self.cfg.n_devices == 1 or move_to_device
@@ -284,6 +288,20 @@ class HookedTransformer(HookedRootModule):
             tokens = tokens[None]
         if tokens.device.type != self.cfg.device:
             tokens = tokens.to(devices.get_device_for_block_index(0, self.cfg))
+        if (
+            self.tokenizer
+            and self.tokenizer.padding_side
+            and self.tokenizer.padding_side == "left"
+        ):
+            attention_mask = torch.tensor(
+                tokens == self.tokenizer.pad_token, dtype=torch.bool
+            )
+            # Fill with smallest possible value.
+            if tokens.dtype.is_floating_point:
+                min_value = torch.finfo(tokens.dtype).min
+            else:
+                min_value = torch.iinfo(tokens.dtype).min
+            tokens.masked_fill_(attention_mask, min_value)
 
         # If we're doing caching, then we reuse keys and values from previous runs, as that's the only
         # way that past activations will affect the final logits. The cache contains those so we don't
@@ -453,6 +471,8 @@ class HookedTransformer(HookedRootModule):
             self.tokenizer.pad_token = self.tokenizer.eos_token
         if self.tokenizer.bos_token is None:
             self.tokenizer.bos_token = self.tokenizer.eos_token
+        if self.left_pad:
+            self.tokenizer.padding_side = "left"
 
         # Infer vocab size from tokenizer
         if self.cfg.d_vocab == -1:

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -477,10 +477,10 @@ class Slice:
             ValueError: If the slice is not an integer and max_ctx is not specified.
         """
         if self.mode == "int":
-            return np.array([self.slice])
+            return np.array([self.slice], dtype=np.int64)
         if max_ctx is None:
             raise ValueError("max_ctx must be specified if slice is not an integer")
-        return np.arange(max_ctx)[self.slice]
+        return np.arange(max_ctx, dtype=np.int64)[self.slice]
 
     def __repr__(
         self,


### PR DESCRIPTION
# Description

Replaces PR #291 because it waited too long and is now too big and messy.

* Added keyword argument left_pad (default False to avoid breaking anything) to HookedTransformer. This keyword argument sets the tokenizer's "padding_side" argument to left if True.
* Added attention mask for when padding_side is left to ensure we don't attend to padded tokens.
* Added test to support this change. (This doesn't need to be tested much because it leverages HuggingFace's implementation - we just have to verify it actually runs in forward)
* Added this change to the Exploratory Analysis Demo.
* Fixed a test in test_utils that was failing by enforcing dtype=np.int64

Fixes #240 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility