### PR TITLE
Reduce memory use when loading model

### DIFF
--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -167,6 +167,8 @@ class HookedRootModule(nn.Module):
         self.mod_dict = {}
         self.hook_dict: Dict[str, HookPoint] = {}
         for name, module in self.named_modules():
+            if name == "":
+                continue
             module.name = name
             self.mod_dict[name] = module
             if "HookPoint" in str(type(module)):

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -940,6 +940,10 @@ def get_pretrained_state_dict(
                 )
 
             # Load model weights, and fold in layer norm weights
+
+        for param in hf_model.parameters():
+            param.requires_grad = False
+
         if cfg.original_architecture == "GPT2LMHeadModel":
             state_dict = convert_gpt2_weights(hf_model, cfg)
         elif cfg.original_architecture == "GPTNeoForCausalLM":


### PR DESCRIPTION
# Description

See discussion in #290

Thanks @rusheb for the testing script and for finding the circular reference.

This PR:
1. Removes circular reference in `HookedRootModule`'s `setup`.
2. Sets `requires_grad=False` before copying weights from HuggingFace models.

Running @rusheb's testing script

```python
from transformer_lens import HookedTransformer
from tqdm import tqdm

for _ in tqdm(range(10)):
    model = HookedTransformer.from_pretrained("gpt2-small", device="cpu")
```

```
Profiler reports peak tracked memory usage

No changes:          17551.0 MiB
Only fix reference:  12416.2 MiB
Only fix gradient:   7342.4 MiB
Fix both:            2207.5 MiB
```

This fix does not help with GPU memory use.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
