### PR TITLE
Fix svd tests on GPU

### DIFF
--- a/tests/unit/test_svd_interpreter.py
+++ b/tests/unit/test_svd_interpreter.py
@@ -49,9 +49,9 @@ def test_svd_interpreter():
         w_out.topk(2, dim=0).values,
     )
     assert ov.shape == w_in.shape == w_out.shape == expected_OV_match.shape
-    assert torch.allclose(ov, expected_OV_match, atol=ATOL)
-    assert torch.allclose(w_in, expected_w_in_match, atol=ATOL)
-    assert torch.allclose(w_out, expected_w_out_match, atol=ATOL)
+    assert torch.allclose(ov.cpu(), expected_OV_match, atol=ATOL)
+    assert torch.allclose(w_in.cpu(), expected_w_in_match, atol=ATOL)
+    assert torch.allclose(w_out.cpu(), expected_w_out_match, atol=ATOL)
 
 
 def test_w_in_when_fold_ln_is_false():
@@ -60,7 +60,7 @@ def test_w_in_when_fold_ln_is_false():
         "w_in", num_vectors=4, layer_index=0, head_index=0
     )
     w_in = w_in.topk(2, dim=0).values
-    assert torch.allclose(w_in, expected_w_in_unfolded_match, atol=ATOL)
+    assert torch.allclose(w_in.cpu(), expected_w_in_unfolded_match, atol=ATOL)
 
 
 def test_svd_interpreter_returns_different_answers_for_different_layers():
@@ -81,9 +81,9 @@ def test_svd_interpreter_returns_different_answers_for_different_layers():
         w_out.topk(2, dim=0).values,
     )
     assert ov.shape == w_in.shape == w_out.shape == expected_OV_match.shape
-    assert not torch.allclose(ov, expected_OV_match, atol=ATOL)
-    assert not torch.allclose(w_in, expected_w_in_match, atol=ATOL)
-    assert not torch.allclose(w_out, expected_w_out_match, atol=ATOL)
+    assert not torch.allclose(ov.cpu(), expected_OV_match, atol=ATOL)
+    assert not torch.allclose(w_in.cpu(), expected_w_in_match, atol=ATOL)
+    assert not torch.allclose(w_out.cpu(), expected_w_out_match, atol=ATOL)
 
 
 def test_svd_interpreter_returns_different_answers_for_different_models():
@@ -103,9 +103,9 @@ def test_svd_interpreter_returns_different_answers_for_different_models():
         w_in.topk(2, dim=0).values,
         w_out.topk(2, dim=0).values,
     )
-    assert not torch.allclose(ov, expected_OV_match, atol=ATOL)
-    assert not torch.allclose(w_in, expected_w_in_match, atol=ATOL)
-    assert not torch.allclose(w_out, expected_w_out_match, atol=ATOL)
+    assert not torch.allclose(ov.cpu(), expected_OV_match, atol=ATOL)
+    assert not torch.allclose(w_in.cpu(), expected_w_in_match, atol=ATOL)
+    assert not torch.allclose(w_out.cpu(), expected_w_out_match, atol=ATOL)
 
 
 # Failures

--- a/tests/unit/test_svd_interpreter.py
+++ b/tests/unit/test_svd_interpreter.py
@@ -14,19 +14,19 @@ second_model = HookedTransformer.from_pretrained("solu-3l")
 
 
 expected_OV_match = torch.Tensor(
-    [[[0.6597, 0.8689, 0.5669, 0.7345]], [[0.5232, 0.6705, 0.5623, 0.7240]]]
+    [[[0.6597, 0.8689, 0.6344, 0.7345]], [[0.5244, 0.6705, 0.5940, 0.7240]]]
 )
 
 expected_w_in_match = torch.Tensor(
-    [[[0.5572, 0.6466, 0.6406, 0.6094]], [[0.5417, 0.6103, 0.5773, 0.5726]]]
+    [[[0.7714, 0.6608, 0.6452, 0.6933]], [[0.7647, 0.6466, 0.6406, 0.6458]]]
 )
 
 expected_w_in_unfolded_match = torch.Tensor(
-    [[[0.2766, 0.3050, 0.3041, 0.3119]], [[0.2651, 0.2988, 0.2810, 0.2896]]]
+    [[[0.3639, 0.3164, 0.3095, 0.3430]], [[0.3614, 0.3050, 0.3041, 0.3140]]]
 )
 
 expected_w_out_match = torch.Tensor(
-    [[[0.5097, 0.4950, 0.5451, 0.7178]], [[0.5076, 0.4922, 0.5140, 0.7106]]]
+    [[[0.5097, 0.5389, 0.7906, 0.7178]], [[0.5076, 0.5350, 0.7674, 0.7106]]]
 )
 
 # Successes
@@ -36,13 +36,14 @@ def test_svd_interpreter():
     svd_interpreter = SVDInterpreter(model)
     ov = svd_interpreter.get_singular_vectors(
         "OV", num_vectors=4, layer_index=0, head_index=0
-    )
+    ).abs()
     w_in = svd_interpreter.get_singular_vectors(
         "w_in", num_vectors=4, layer_index=0, head_index=0
-    )
+    ).abs()
     w_out = svd_interpreter.get_singular_vectors(
         "w_out", num_vectors=4, layer_index=0, head_index=0
-    )
+    ).abs()
+
     ov, w_in, w_out = (
         ov.topk(2, dim=0).values,
         w_in.topk(2, dim=0).values,
@@ -58,7 +59,7 @@ def test_w_in_when_fold_ln_is_false():
     svd_interpreter = SVDInterpreter(unfolded_model)
     w_in = svd_interpreter.get_singular_vectors(
         "w_in", num_vectors=4, layer_index=0, head_index=0
-    )
+    ).abs()
     w_in = w_in.topk(2, dim=0).values
     assert torch.allclose(w_in.cpu(), expected_w_in_unfolded_match, atol=ATOL)
 
@@ -67,13 +68,13 @@ def test_svd_interpreter_returns_different_answers_for_different_layers():
     svd_interpreter = SVDInterpreter(model)
     ov = svd_interpreter.get_singular_vectors(
         "OV", layer_index=1, num_vectors=4, head_index=0
-    )
+    ).abs()
     w_in = svd_interpreter.get_singular_vectors(
         "w_in", layer_index=1, num_vectors=4, head_index=0
-    )
+    ).abs()
     w_out = svd_interpreter.get_singular_vectors(
         "w_out", layer_index=1, num_vectors=4, head_index=0
-    )
+    ).abs()
 
     ov, w_in, w_out = (
         ov.topk(2, dim=0).values,
@@ -90,13 +91,13 @@ def test_svd_interpreter_returns_different_answers_for_different_models():
     svd_interpreter = SVDInterpreter(second_model)
     ov = svd_interpreter.get_singular_vectors(
         "OV", layer_index=1, num_vectors=4, head_index=0
-    )
+    ).abs()
     w_in = svd_interpreter.get_singular_vectors(
         "w_in", layer_index=1, num_vectors=4, head_index=0
-    )
+    ).abs()
     w_out = svd_interpreter.get_singular_vectors(
         "w_out", layer_index=1, num_vectors=4, head_index=0
-    )
+    ).abs()
 
     ov, w_in, w_out = (
         ov.topk(2, dim=0).values,


### PR DESCRIPTION
# Description

Fixes #328 

1. Moves tensors to CPU before checking with `assert`
2. Checks absolute value of SVD vectors instead of the vectors themselves.

As I mentioned in #328, SVD is not numerically stable so different hardware gives different results. From the pytorch docs: `This non-uniqueness is caused by the fact that multiplying any pair of singular vectors u_k, v_k by -1 in the real case produces another two valid singular vectors of the matrix.` So I think comparing `v.abs()` in the tests should get around this issue.

I have run the tests on M1 Mac, Ubuntu with GPU, Ubuntu without GPU.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
