### PR TITLE
Fix API docs

### DIFF
--- a/docs/source/transformer_lens.rst
+++ b/docs/source/transformer_lens.rst
@@ -52,6 +52,14 @@ transformer\_lens.HookedTransformerConfig module
    :undoc-members:
    :show-inheritance:
 
+transformer\_lens.SVDInterpreter module
+---------------------------------------
+
+.. automodule:: transformer_lens.SVDInterpreter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 transformer\_lens.components module
 -----------------------------------
 


### PR DESCRIPTION
# Description

The docs have drifted out of sync. (This diff was generated by https://github.com/neelnanda-io/TransformerLens/pull/338 and the check passed when pushed to that branch.)

## Type of change

Documentation update.

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->