### PR TITLE
Scalar multiplication

### DIFF
--- a/tests/unit/factored_matrix/test_multiply_by_scalar.py
+++ b/tests/unit/factored_matrix/test_multiply_by_scalar.py
@@ -50,4 +50,10 @@ def test_multiply(scalar, leading_dim, multiply_from_left, error_expected):
         if multiply_from_left:
             assert_close((fm * scalar).AB, (a @ b) * scalar)
         else:
-            assert_close((scalar * fm).AB, (a @ b) * scalar)
+            assert_close((scalar * fm).AB, scalar * (a @ b))
+        # This next test is implementation dependant and can be broken and removed at any time!
+        # It checks that the multiplication is performed on the A factor matrix.
+        if multiply_from_left:
+            assert_close((fm * scalar).A, a * scalar)
+        else:
+            assert_close((scalar * fm).A, scalar * a)

--- a/tests/unit/factored_matrix/test_multiply_by_scalar.py
+++ b/tests/unit/factored_matrix/test_multiply_by_scalar.py
@@ -4,29 +4,38 @@ from torch.testing import assert_close
 
 from transformer_lens import FactoredMatrix
 
+# This test function is parametrized with different types of scalars, including non-scalar tensors and arrays, to check that the correct errors are raised.
+# Considers cases with and without leading dimensions as well as left and right multiplication.
 @pytest.mark.parametrize(
-    "scalar", 
+    "scalar, error_expected", 
     [
-        torch.rand(1), 
-        float(torch.rand(1).item()), 
-        int(torch.randint(1, 10, (1,)).item())
+        # Test cases with different types of scalar values.
+        (torch.rand(1), None),  # 1-element Tensor. No error expected.
+        (float(torch.rand(1).item()), None),  # float. No error expected.
+        (int(torch.randint(1, 10, (1,)).item()), None),  # int. No error expected.
+
+        # Test cases with non-scalar values that are expected to raise errors.
+        (torch.rand(2, 2), AssertionError),  # Non-scalar Tensor. AssertionError expected.
+        (torch.rand(2), AssertionError),  # Non-scalar Tensor. AssertionError expected.
+
     ]
 )
 @pytest.mark.parametrize(
     "leading_dim", 
     [
-        False, 
+        False,
         True
     ]
 )
 @pytest.mark.parametrize(
     "multiply_from_left", 
     [
-        False, 
+        False,
         True
     ]
 )
-def test_multiply_by_scalar(scalar, leading_dim, multiply_from_left):
+def test_multiply(scalar, leading_dim, multiply_from_left, error_expected):
+    # Prepare a FactoredMatrix, with or without leading dimensions
     if leading_dim:
         a = torch.rand(6, 2, 3)
         b = torch.rand(6, 3, 4)
@@ -36,7 +45,17 @@ def test_multiply_by_scalar(scalar, leading_dim, multiply_from_left):
 
     fm = FactoredMatrix(a, b)
 
-    if multiply_from_left:
-        assert_close((fm * scalar).AB, (a @ b) * scalar)
+    if error_expected:
+        # If an error is expected, check that the correct exception is raised.
+        with pytest.raises(error_expected):
+            if multiply_from_left:
+                _ = fm * scalar
+            else:
+                _ = scalar * fm
     else:
-        assert_close((scalar * fm).AB, (a @ b) * scalar)
+        # If no error is expected, check that the multiplication results in the correct value.
+        # Use FactoredMatrix.AB to calculate the product of the two factor matrices before comparing with the expected value.
+        if multiply_from_left:
+            assert_close((fm * scalar).AB, (a @ b) * scalar)
+        else:
+            assert_close((scalar * fm).AB, (a @ b) * scalar)

--- a/tests/unit/factored_matrix/test_multiply_by_scalar.py
+++ b/tests/unit/factored_matrix/test_multiply_by_scalar.py
@@ -4,6 +4,7 @@ from torch.testing import assert_close
 
 from transformer_lens import FactoredMatrix
 
+
 # This test function is parametrized with different types of scalars, including non-scalar tensors and arrays, to check that the correct errors are raised.
 # Considers cases with and without leading dimensions as well as left and right multiplication.
 @pytest.mark.parametrize(

--- a/tests/unit/factored_matrix/test_multiply_by_scalar.py
+++ b/tests/unit/factored_matrix/test_multiply_by_scalar.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 import torch
 from torch.testing import assert_close
@@ -12,8 +14,8 @@ from transformer_lens import FactoredMatrix
     [
         # Test cases with different types of scalar values.
         (torch.rand(1), None),  # 1-element Tensor. No error expected.
-        (float(torch.rand(1).item()), None),  # float. No error expected.
-        (int(torch.randint(1, 10, (1,)).item()), None),  # int. No error expected.
+        (random.random(), None),  # float. No error expected.
+        (random.randint(-100, 100), None),  # int. No error expected.
         # Test cases with non-scalar values that are expected to raise errors.
         (
             torch.rand(2, 2),

--- a/tests/unit/factored_matrix/test_multiply_by_scalar.py
+++ b/tests/unit/factored_matrix/test_multiply_by_scalar.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+from torch.testing import assert_close
+
+from transformer_lens import FactoredMatrix
+
+@pytest.mark.parametrize(
+    "scalar", 
+    [
+        torch.rand(1), 
+        float(torch.rand(1).item()), 
+        int(torch.randint(1, 10, (1,)).item())
+    ]
+)
+@pytest.mark.parametrize(
+    "leading_dim", 
+    [
+        False, 
+        True
+    ]
+)
+@pytest.mark.parametrize(
+    "multiply_from_left", 
+    [
+        False, 
+        True
+    ]
+)
+def test_multiply_by_scalar(scalar, leading_dim, multiply_from_left):
+    if leading_dim:
+        a = torch.rand(6, 2, 3)
+        b = torch.rand(6, 3, 4)
+    else:
+        a = torch.rand(2, 3)
+        b = torch.rand(3, 4)
+
+    fm = FactoredMatrix(a, b)
+
+    if multiply_from_left:
+        assert_close((fm * scalar).AB, (a @ b) * scalar)
+    else:
+        assert_close((scalar * fm).AB, (a @ b) * scalar)

--- a/tests/unit/factored_matrix/test_multiply_by_scalar.py
+++ b/tests/unit/factored_matrix/test_multiply_by_scalar.py
@@ -8,33 +8,22 @@ from transformer_lens import FactoredMatrix
 # This test function is parametrized with different types of scalars, including non-scalar tensors and arrays, to check that the correct errors are raised.
 # Considers cases with and without leading dimensions as well as left and right multiplication.
 @pytest.mark.parametrize(
-    "scalar, error_expected", 
+    "scalar, error_expected",
     [
         # Test cases with different types of scalar values.
         (torch.rand(1), None),  # 1-element Tensor. No error expected.
         (float(torch.rand(1).item()), None),  # float. No error expected.
         (int(torch.randint(1, 10, (1,)).item()), None),  # int. No error expected.
-
         # Test cases with non-scalar values that are expected to raise errors.
-        (torch.rand(2, 2), AssertionError),  # Non-scalar Tensor. AssertionError expected.
+        (
+            torch.rand(2, 2),
+            AssertionError,
+        ),  # Non-scalar Tensor. AssertionError expected.
         (torch.rand(2), AssertionError),  # Non-scalar Tensor. AssertionError expected.
-
-    ]
+    ],
 )
-@pytest.mark.parametrize(
-    "leading_dim", 
-    [
-        False,
-        True
-    ]
-)
-@pytest.mark.parametrize(
-    "multiply_from_left", 
-    [
-        False,
-        True
-    ]
-)
+@pytest.mark.parametrize("leading_dim", [False, True])
+@pytest.mark.parametrize("multiply_from_left", [False, True])
 def test_multiply(scalar, leading_dim, multiply_from_left, error_expected):
     # Prepare a FactoredMatrix, with or without leading dimensions
     if leading_dim:

--- a/transformer_lens/FactoredMatrix.py
+++ b/transformer_lens/FactoredMatrix.py
@@ -90,7 +90,7 @@ class FactoredMatrix:
         Left scalar multiplication. Scalar multiplication distributes over matrix multiplication, so we can just multiply one of the factor matrices by the scalar.
         """
         if isinstance(scalar, torch.Tensor):
-            assert scalar.numel() == 1, "The tensor must be a scalar for use with *. For multiplication by a matrix or vector, use @."
+            assert scalar.numel() == 1, f"Tensor must be a scalar for use with * but was of shape {scalar.shape}. For matrix multiplication, use @ instead."
         return FactoredMatrix(self.A * scalar, self.B)
 
     def __rmul__(

--- a/transformer_lens/FactoredMatrix.py
+++ b/transformer_lens/FactoredMatrix.py
@@ -81,6 +81,26 @@ class FactoredMatrix:
                 return FactoredMatrix(other, self.AB)
         elif isinstance(other, FactoredMatrix):
             return other.A @ (other.B @ self)
+        
+    def __mul__(
+        self,
+        scalar: Union[int, float, torch.Tensor]
+    ) -> FactoredMatrix:
+        """
+        Left scalar multiplication. Scalar multiplication distributes over matrix multiplication, so we can just multiply one of the factor matrices by the scalar.
+        """
+        if isinstance(scalar, torch.Tensor):
+            assert scalar.numel() == 1, "The tensor must be a scalar for use with *. For multiplication by a matrix or vector, use @."
+        return FactoredMatrix(self.A * scalar, self.B)
+
+    def __rmul__(
+        self,
+        scalar: Union[int, float, torch.Tensor]
+    ) -> FactoredMatrix:
+        """
+        Right scalar multiplication. For scalar multiplication from the right, we can reuse the __mul__ method.
+        """
+        return self * scalar
 
     @property
     @typeguard_ignore

--- a/transformer_lens/FactoredMatrix.py
+++ b/transformer_lens/FactoredMatrix.py
@@ -81,22 +81,18 @@ class FactoredMatrix:
                 return FactoredMatrix(other, self.AB)
         elif isinstance(other, FactoredMatrix):
             return other.A @ (other.B @ self)
-        
-    def __mul__(
-        self,
-        scalar: Union[int, float, torch.Tensor]
-    ) -> FactoredMatrix:
+
+    def __mul__(self, scalar: Union[int, float, torch.Tensor]) -> FactoredMatrix:
         """
         Left scalar multiplication. Scalar multiplication distributes over matrix multiplication, so we can just multiply one of the factor matrices by the scalar.
         """
         if isinstance(scalar, torch.Tensor):
-            assert scalar.numel() == 1, f"Tensor must be a scalar for use with * but was of shape {scalar.shape}. For matrix multiplication, use @ instead."
+            assert (
+                scalar.numel() == 1
+            ), f"Tensor must be a scalar for use with * but was of shape {scalar.shape}. For matrix multiplication, use @ instead."
         return FactoredMatrix(self.A * scalar, self.B)
 
-    def __rmul__(
-        self,
-        scalar: Union[int, float, torch.Tensor]
-    ) -> FactoredMatrix:
+    def __rmul__(self, scalar: Union[int, float, torch.Tensor]) -> FactoredMatrix:
         """
         Right scalar multiplication. For scalar multiplication from the right, we can reuse the __mul__ method.
         """


### PR DESCRIPTION
# Description

Implemented __mul__ and __rmul__ for Factoredmatrix to support scalar multiplication with *.
Supports floats, ints and single-element Tensors.
Approriate error messages and test are in place.

Fixes #348 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility