### PR TITLE
Remove n_devices assert in config

### DIFF
--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -234,9 +234,6 @@ class HookedTransformerConfig:
 
         if self.n_devices > 1:
             assert (
-                self.device == "cuda"
-            ), "n_devices > 1 is only supported on CUDA devices"
-            assert (
                 torch.cuda.device_count() >= self.n_devices
             ), f"Not enough CUDA devices to support n_devices {self.n_devices}"
 

--- a/transformer_lens/utilities/devices.py
+++ b/transformer_lens/utilities/devices.py
@@ -47,8 +47,7 @@ def move_to_and_update_config(
     print_details=True,
 ):
     """
-    Wrapper around to that also changes model.cfg.device if it's a torch.device or string.
-    If torch.dtype, just passes through
+    Wrapper around `to` that also updates `model.cfg`.
     """
     if isinstance(device_or_dtype, torch.device):
         model.cfg.device = device_or_dtype.type


### PR DESCRIPTION
# Description

Fixes #356 by removing the device check in `HookedTransformerConfig`.

This assert didn’t make sense as it should be possible to first load the model on CPU and then move it to devices.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
