### PR TITLE
Fix bug in rotary embedding for models other than llama and gpt-neo

### DIFF
--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -692,10 +692,7 @@ class Attention(nn.Module):
         GPT-NeoX and GPT-J do rotary subtly differently, see calculate_sin_cos_rotary for details.
         """
         rot_x = x.clone()
-        if (
-            self.cfg.original_architecture
-            in ["GPTNeoXForCausalLM", "LlamaForCausalLM"],
-        ):
+        if self.cfg.original_architecture in ["GPTNeoXForCausalLM", "LlamaForCausalLM"]:
             n = x.size(-1) // 2
             rot_x[..., :n] = -x[..., n:]
             rot_x[..., n:] = x[..., :n]


### PR DESCRIPTION
# Description

This PR fixes the bug in the calculation of rotary embedding, which affects the performance of the models that use rotary embedding other than llama and gpt-neo, e.g., gpt-j.

https://github.com/neelnanda-io/TransformerLens/blob/bf5ed27cef2a566377151228acd5c7eb1b641195/transformer_lens/components.py#L697

```
        if (
            self.cfg.original_architecture
            in ["GPTNeoXForCausalLM", "LlamaForCausalLM"],  # the , at the end causes the bug
        ):
            n = x.size(-1) // 2
            rot_x[..., :n] = -x[..., n:]
            rot_x[..., n:] = x[..., :n]
        else:
            rot_x[..., ::2] = -x[..., 1::2]
            rot_x[..., 1::2] = x[..., ::2]
```

Let's say that `self.cfg.original_architecture = 'GPTJForCausalLM'`. Then, the desired behaviour is to execute the `else` branch because `self.cfg.original_architecture` is not in `["GPTNeoXForCausalLM", "LlamaForCausalLM"]`.
However, because of the "," at the end of L697, the if clause becomes `if (False,)`, which is interpreted as `if True` and executes the `if` branch.

Fixes #364 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility