### PR TITLE
fix: Set IGNORE value in mask to -torch.inf

### DIFF
--- a/tests/unit/test_attention_mask.py
+++ b/tests/unit/test_attention_mask.py
@@ -1,0 +1,52 @@
+import torch
+
+from transformer_lens import utils
+from transformer_lens.HookedTransformer import HookedTransformer
+from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
+
+
+def test_attention_mask():
+    # Verify the attention mask attends properly, including for low attention scores
+    cfg = HookedTransformerConfig(
+        d_head=1,
+        d_model=12,
+        d_vocab=2,
+        n_ctx=5,
+        n_layers=1,
+        attn_only=True,
+        attention_dir="causal",
+    )
+    model = HookedTransformer(cfg)
+    input_length = 5
+    input = torch.ones((1, input_length), dtype=torch.int64)
+    layer = 0
+    low_attn_score = 1e-6
+    ones_input_matrix = torch.ones((input_length, input_length))
+
+    def attn_scores_hook(attn_scores, hook):
+        upper_right_mask = torch.triu(ones_input_matrix, diagonal=1)
+        lower_left_mask = torch.tril(ones_input_matrix)
+
+        assert torch.all(
+            attn_scores[:, :, upper_right_mask.bool()] == float("-inf")
+        ), "Attention scores excluded by the mask are not being set to -inf"
+
+        # Set low attention scores that are attended to by the mask
+        attn_scores[:, :, lower_left_mask.bool()] = low_attn_score
+
+        return attn_scores
+
+    def attn_hook(attn, hook):
+        upper_right_mask = torch.triu(ones_input_matrix, diagonal=1)
+        assert torch.all(
+            attn[:, :, upper_right_mask.bool()] == 0
+        ), "Attention pattern attends outside the mask"
+
+        return attn
+
+    fwd_hooks = [
+        (utils.get_act_name("attn_scores", layer), attn_scores_hook),
+        (utils.get_act_name("attn", layer), attn_hook),
+    ]
+
+    model.run_with_hooks(input, fwd_hooks=fwd_hooks)

--- a/transformer_lens/HookedEncoder.py
+++ b/transformer_lens/HookedEncoder.py
@@ -120,8 +120,16 @@ class HookedEncoder(HookedRootModule):
         resid = self.hook_full_embed(self.embed(tokens, token_type_ids))
 
         large_negative_number = -torch.inf
-        mask = repeat(1 - one_zero_attention_mask, "batch pos -> batch 1 1 pos") if one_zero_attention_mask is not None else None
-        additive_attention_mask = torch.where(mask == 1, large_negative_number, 0) if mask is not None else None
+        mask = (
+            repeat(1 - one_zero_attention_mask, "batch pos -> batch 1 1 pos")
+            if one_zero_attention_mask is not None
+            else None
+        )
+        additive_attention_mask = (
+            torch.where(mask == 1, large_negative_number, 0)
+            if mask is not None
+            else None
+        )
 
         for block in self.blocks:
             resid = block(resid, additive_attention_mask)

--- a/transformer_lens/HookedEncoder.py
+++ b/transformer_lens/HookedEncoder.py
@@ -119,13 +119,9 @@ class HookedEncoder(HookedRootModule):
 
         resid = self.hook_full_embed(self.embed(tokens, token_type_ids))
 
-        large_negative_number = -1e5
-        additive_attention_mask = (
-            large_negative_number
-            * repeat(1 - one_zero_attention_mask, "batch pos -> batch 1 1 pos")
-            if one_zero_attention_mask is not None
-            else None
-        )
+        large_negative_number = -torch.inf
+        mask = repeat(1 - one_zero_attention_mask, "batch pos -> batch 1 1 pos") if one_zero_attention_mask is not None else None
+        additive_attention_mask = torch.where(mask == 1, large_negative_number, 0) if mask is not None else None
 
         for block in self.blocks:
             resid = block(resid, additive_attention_mask)

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -408,7 +408,7 @@ class Attention(nn.Module):
         else:
             raise ValueError(f"Invalid attention type: {self.attn_type}")
 
-        self.register_buffer("IGNORE", torch.tensor(-1e5))
+        self.register_buffer("IGNORE", torch.tensor(-torch.inf))
 
         self.layer_id = layer_id
 


### PR DESCRIPTION
# Description

Supersedes https://github.com/neelnanda-io/TransformerLens/pull/319. Just copied the changes + the final requested change.

From the other PR description:
"Fixes https://github.com/neelnanda-io/TransformerLens/issues/318 - In pythia-70m, attn_scores can get below -1e5 (for some reason...). Masked attn scores are set to -1e5, so this makes the model attend outside the mask! This is dumb, and so I set things to -torch.inf instead. It's still registered as a buffer so should move to device + dtypes accordingly"


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->