### PR TITLE
Fix FactoredMatrix bug

### DIFF
--- a/tests/unit/factored_matrix/test_get_item.py
+++ b/tests/unit/factored_matrix/test_get_item.py
@@ -54,3 +54,26 @@ def test_index_dimension_get_element(sample_factored_matrix):
 def test_index_dimension_too_big(sample_factored_matrix):
     with pytest.raises(Exception):
         _ = sample_factored_matrix[1, 1, 1, 1, 1, 1]
+
+
+def test_getitem_sequences(sample_factored_matrix):
+    A_idx = [0, 1]
+    B_idx = [0]
+    result = sample_factored_matrix[:, :, :, A_idx, B_idx]
+    t.testing.assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
+    t.testing.assert_close(result.B, sample_factored_matrix.B[:, :, :, :, B_idx])
+
+def test_getitem_sequences_and_ints(sample_factored_matrix):
+    A_idx = [0, 1]
+    B_idx = 0
+    result = sample_factored_matrix[:, :, :, A_idx, B_idx]
+    t.testing.assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
+    # we squeeze result.B, because indexing by ints is designed not to delete dimensions
+    t.testing.assert_close(result.B.squeeze(-1), sample_factored_matrix.B[:, :, :, :, B_idx])
+
+def test_getitem_tensors(sample_factored_matrix):
+    A_idx = t.tensor([0, 1])
+    B_idx = t.tensor([0])
+    result = sample_factored_matrix[:, :, :, A_idx, B_idx]
+    t.testing.assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
+    t.testing.assert_close(result.B, sample_factored_matrix.B[:, :, :, :, B_idx])

--- a/tests/unit/factored_matrix/test_get_item.py
+++ b/tests/unit/factored_matrix/test_get_item.py
@@ -60,20 +60,25 @@ def test_getitem_sequences(sample_factored_matrix):
     A_idx = [0, 1]
     B_idx = [0]
     result = sample_factored_matrix[:, :, :, A_idx, B_idx]
-    t.testing.assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
-    t.testing.assert_close(result.B, sample_factored_matrix.B[:, :, :, :, B_idx])
+    assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
+    assert_close(result.B, sample_factored_matrix.B[:, :, :, :, B_idx])
+
 
 def test_getitem_sequences_and_ints(sample_factored_matrix):
     A_idx = [0, 1]
     B_idx = 0
     result = sample_factored_matrix[:, :, :, A_idx, B_idx]
-    t.testing.assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
+    assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
     # we squeeze result.B, because indexing by ints is designed not to delete dimensions
-    t.testing.assert_close(result.B.squeeze(-1), sample_factored_matrix.B[:, :, :, :, B_idx])
+    assert_close(
+        result.B.squeeze(-1),
+        sample_factored_matrix.B[:, :, :, :, B_idx]
+    )
+
 
 def test_getitem_tensors(sample_factored_matrix):
-    A_idx = t.tensor([0, 1])
-    B_idx = t.tensor([0])
+    A_idx = torch.tensor([0, 1])
+    B_idx = torch.tensor([0])
     result = sample_factored_matrix[:, :, :, A_idx, B_idx]
-    t.testing.assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
-    t.testing.assert_close(result.B, sample_factored_matrix.B[:, :, :, :, B_idx])
+    assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
+    assert_close(result.B, sample_factored_matrix.B[:, :, :, :, B_idx])

--- a/tests/unit/factored_matrix/test_get_item.py
+++ b/tests/unit/factored_matrix/test_get_item.py
@@ -70,10 +70,7 @@ def test_getitem_sequences_and_ints(sample_factored_matrix):
     result = sample_factored_matrix[:, :, :, A_idx, B_idx]
     assert_close(result.A, sample_factored_matrix.A[:, :, :, A_idx, :])
     # we squeeze result.B, because indexing by ints is designed not to delete dimensions
-    assert_close(
-        result.B.squeeze(-1),
-        sample_factored_matrix.B[:, :, :, :, B_idx]
-    )
+    assert_close(result.B.squeeze(-1), sample_factored_matrix.B[:, :, :, :, B_idx])
 
 
 def test_getitem_tensors(sample_factored_matrix):

--- a/transformer_lens/FactoredMatrix.py
+++ b/transformer_lens/FactoredMatrix.py
@@ -155,11 +155,12 @@ class FactoredMatrix:
 
     def _convert_to_slice(self, sequence: Union[Tuple, List], idx: int) -> Tuple:
         """
-        e.g. if sequence = (1, 2, 3) and idx = 1, return (1, slice(2, 3), 3)
+        e.g. if sequence = (1, 2, 3) and idx = 1, return (1, slice(2, 3), 3). This only edits elements if they are ints.
         """
         if isinstance(idx, int):
             sequence = list(sequence)
-            sequence[idx] = slice(sequence[idx], sequence[idx] + 1)
+            if isinstance(sequence[idx], int):
+                sequence[idx] = slice(sequence[idx], sequence[idx] + 1)
             sequence = tuple(sequence)
 
         return sequence


### PR DESCRIPTION
# Description

The function `_convert_to_slice` was added recently, which causes indexing with elements to work (previously this didn't work). But when this change was made, it caused indexing with sequences to work. 

## Type of change

The solution is to make `_convert_to_slice` only alter integer elements of the index.

To further explain, `_convert_to_slice` will take an integer like `1` and convert it into the slice `slice(1, 2)`. This is good because now the indexed tensors `A` and `B` have the correct number of dimensions (i.e. they don't lose a dimension). But this isn't how we should treat things like `t.tensor([0, 1, 2])` when they're used as an index, because they're already in the correct form for indexing (i.e. indexing with them won't delete a dimension).

I've now added tests to `tests/unit/factored_matrix/test_get_item.py` which would have failed on both the version of TransformerLens before the recent change to FactoredMatrix, and the version after this change, but which now all pass.

### Screenshots

![three_versions](https://github.com/neelnanda-io/TransformerLens/assets/45238458/c03c098a-fed7-4683-9715-b8c8c84725fb)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility