### PR TITLE
Fix to automatically infer add_special_tokens for tokenizer

### DIFF
--- a/tests/unit/test_prepend_bos.py
+++ b/tests/unit/test_prepend_bos.py
@@ -13,9 +13,7 @@ class TestPrependBos:
         # copied from HookedTransformer.to_tokens()
         tokens = tokenizer(
             prompt,
-            add_special_tokens=False
-            if model.tokenizer.name_or_path.startswith("facebook/opt")
-            else True,  # As we manually add the BOS token
+            add_special_tokens=model.cfg.add_special_tokens,
         )["input_ids"]
 
         return len(tokens) + int(intended_prepend_bos)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -469,7 +469,10 @@ class HookedTransformer(HookedRootModule):
 
         # If the tokenizer prepends the BOS token to the input by default, turn it off.
         # We manually control whether or not to prepend BOS tokens.
-        self.cfg.add_special_tokens = len(self.tokenizer("")["input_ids"]) == 0
+        self.cfg.add_special_tokens = not (
+            len(self.tokenizer("")["input_ids"]) > 0
+            and self.tokenizer("")["input_ids"][0] == self.tokenizer.bos_token_id
+        )
 
     def to_tokens(
         self,

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -467,6 +467,10 @@ class HookedTransformer(HookedRootModule):
         if self.cfg.d_vocab_out == -1:
             self.cfg.d_vocab_out = self.cfg.d_vocab
 
+        # If the tokenizer prepends the BOS token to the input by default, turn it off.
+        # We manually control whether or not to prepend BOS tokens.
+        self.cfg.add_special_tokens = len(self.tokenizer("")["input_ids"]) == 0
+
     def to_tokens(
         self,
         input: Union[str, List[str]],
@@ -497,6 +501,9 @@ class HookedTransformer(HookedRootModule):
         capitalized. It's easy to shoot yourself in the foot here if you're not careful!
         """
         assert self.tokenizer is not None, "Cannot use to_tokens without a tokenizer"
+        assert (
+            self.cfg.add_special_tokens is not None
+        ), "Set the tokenizer for the model by calling set_tokenizer"
 
         # Use the provided prepend_bos as an override if it's not None;
         # otherwise use self.cfg.default_prepend_bos (defaults to True unless specified otherwise)
@@ -515,9 +522,7 @@ class HookedTransformer(HookedRootModule):
             padding=True,
             truncation=truncate,
             max_length=self.cfg.n_ctx if truncate else None,
-            add_special_tokens=False
-            if self.tokenizer.name_or_path.startswith("facebook/opt")
-            else True,  # As we manually add the BOS token
+            add_special_tokens=self.cfg.add_special_tokens,
         )["input_ids"]
         if move_to_device:
             tokens = tokens.to(self.cfg.device)

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -182,6 +182,7 @@ class HookedTransformerConfig:
     gated_mlp: bool = False
     default_prepend_bos: bool = True
     dtype: torch.dtype = torch.float32
+    add_special_tokens: Optional[bool] = None  # will be set by set_tokenizer
 
     def __post_init__(self):
         if self.n_heads == -1:


### PR DESCRIPTION
# Description

Remove the hard-coded part that determines the value to be passed to `tokenizer(add_special_tokens=...)` in `to_tokens()` that is prone to bugs like #369.

Automatically infer the value to be passed as follows:
```python3
add_special_tokens = not (
    len(self.tokenizer("")["input_ids"]) > 0
    and self.tokenizer("")["input_ids"][0] == self.tokenizer.bos_token_id
)
```
Set this value as `add_special_tokens` in `HookedTransformerConfig` when `set_tokenizer()` is called. The value is set to `None` until `set_tokenizer` is called.

When calling `to_tokens()`, do a simple sanity check by ensuring `model.cfg.add_special_tokens` is not `None` to better ensure that the tokenizer is set using `set_tokenizer()` and thus `add_special_tokens` is set correctly.

Fixes #369

## Before Bug Fix
```python3
# Case of default_prepend_bos = True
model = HookedTransformer.from_pretrained(
    "llama-7b-hf",
    hf_model=llama_7b_hf,
    tokenizer=llama_7b_tokenizer,
)
model.to_str_tokens('hello world!')
>>> ['<s>', '<s>', 'hello', 'world', '!']  # <s> should be prepended once, but is prepended twice

# Case of default_prepend_bos = False
model = HookedTransformer.from_pretrained(
    "llama-7b-hf",
    hf_model=llama_7b_hf,
    tokenizer=llama_7b_tokenizer,
    default_prepend_bos=False,
)
model.to_str_tokens('hello world!')
>>> ['<s>', 'hello', 'world', '!']  # <s> should not be prepended, but is prepended
```

## After Bug Fix
```python3
# Case of default_prepend_bos = True
model = HookedTransformer.from_pretrained(
    "llama-7b-hf",
    hf_model=llama_7b_hf,
    tokenizer=llama_7b_tokenizer,
)
model.to_str_tokens('hello world!')
>>> ['<s>', 'hello', 'world', '!']

# Case of default_prepend_bos = False
model = HookedTransformer.from_pretrained(
    "llama-7b-hf",
    hf_model=llama_7b_hf,
    tokenizer=llama_7b_tokenizer,
    default_prepend_bos=False,
)
model.to_str_tokens('hello world!')
>>> ['hello', 'world', '!']
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility