### PR TITLE
Added gated MLP Hooks

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1656,6 +1656,17 @@ class HookedTransformer(HookedRootModule):
 
     @property
     @lru_cache(maxsize=None)
+    def W_gate(self) -> Float[torch.Tensor, "n_layers d_model d_mlp"]:
+        """Stacks the MLP gate weights across all layers.
+        
+        Only works for models with gated MLPs"""
+        if self.cfg.gated_mlp:
+            return torch.stack([block.mlp.W_gate for block in self.blocks], dim=0)
+        else:
+            return None
+
+    @property
+    @lru_cache(maxsize=None)
     def W_out(self) -> Float[torch.Tensor, "n_layers d_mlp d_model"]:
         """Stacks the MLP output weights across all layers"""
         return torch.stack([block.mlp.W_out for block in self.blocks], dim=0)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1658,7 +1658,7 @@ class HookedTransformer(HookedRootModule):
     @lru_cache(maxsize=None)
     def W_gate(self) -> Float[torch.Tensor, "n_layers d_model d_mlp"]:
         """Stacks the MLP gate weights across all layers.
-        
+
         Only works for models with gated MLPs"""
         if self.cfg.gated_mlp:
             return torch.stack([block.mlp.W_gate for block in self.blocks], dim=0)

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -786,7 +786,7 @@ class MLP(nn.Module):
 # not sure whether to fold this into MLP or not
 class GatedMLP(nn.Module):
     """
-    The equation of a gated MLP: 
+    The equation of a gated MLP:
     pre = x @ W_gate
     pre_linear = x @ W_in
     post = Gelu(pre) * (pre_linear) + b_in
@@ -794,6 +794,7 @@ class GatedMLP(nn.Module):
 
     In one equation, mlp_out = (Gelu(x @ W_gate) * (x @ W_in) + b_in) @ W_out + b_out
     """
+
     def __init__(self, cfg: Union[Dict, HookedTransformerConfig]):
         super().__init__()
         if isinstance(cfg, Dict):
@@ -850,13 +851,13 @@ class GatedMLP(nn.Module):
             )
         )  # [batch, pos, d_mlp]
         if not self.cfg.act_fn.endswith("_ln"):
-            pre_linear = self.hook_pre_linear(einsum(
-                "batch pos d_model, d_model d_mlp -> batch pos d_mlp", x, self.W_in
-            ))
+            pre_linear = self.hook_pre_linear(
+                einsum(
+                    "batch pos d_model, d_model d_mlp -> batch pos d_mlp", x, self.W_in
+                )
+            )
             post_act = self.hook_post(
-                (self.act_fn(pre_act)
-                * pre_linear)
-                + self.b_in
+                (self.act_fn(pre_act) * pre_linear) + self.b_in
             )  # [batch, pos, d_mlp]
         else:
             mid_act = self.hook_mid(self.act_fn(pre_act))  # [batch, pos, d_mlp]

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -785,6 +785,15 @@ class MLP(nn.Module):
 # TODO
 # not sure whether to fold this into MLP or not
 class GatedMLP(nn.Module):
+    """
+    The equation of a gated MLP: 
+    pre = x @ W_gate
+    pre_linear = x @ W_in
+    post = Gelu(pre) * (pre_linear) + b_in
+    mlp_out = post @ W_out + b_out
+
+    In one equation, mlp_out = (Gelu(x @ W_gate) * (x @ W_in) + b_in) @ W_out + b_out
+    """
     def __init__(self, cfg: Union[Dict, HookedTransformerConfig]):
         super().__init__()
         if isinstance(cfg, Dict):
@@ -841,11 +850,12 @@ class GatedMLP(nn.Module):
             )
         )  # [batch, pos, d_mlp]
         if not self.cfg.act_fn.endswith("_ln"):
+            pre_linear = self.hook_pre_linear(einsum(
+                "batch pos d_model, d_model d_mlp -> batch pos d_mlp", x, self.W_in
+            ))
             post_act = self.hook_post(
-                self.act_fn(pre_act)
-                * self.hook_pre_linear(einsum(
-                    "batch pos d_model, d_model d_mlp -> batch pos d_mlp", x, self.W_in
-                ))
+                (self.act_fn(pre_act)
+                * pre_linear)
                 + self.b_in
             )  # [batch, pos, d_mlp]
         else:

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -578,7 +578,7 @@ def get_act_name(
         "attn_scores",
     ]:
         layer_type = "attn"
-    elif name in ["pre", "post", "mid"]:
+    elif name in ["pre", "post", "mid", "pre_linear"]:
         layer_type = "mlp"
     elif layer_type in layer_type_alias:
         layer_type = layer_type_alias[layer_type]


### PR DESCRIPTION
# Description

Added a hook for the linear input of a gated MLP. Called `hook_pre_linear`

Current structure:

There are 3 weight matrices for the MLP, W_gate, W_in, and W_out

Given an input resid_mid, we compute 

hook_pre = resid_mid @ W_gate
hook_pre_linear = resid_mid @ W_in
hook_post = act_fn(hook_pre) * hook_pre_linear + b_in
hook_mlp_out = hook_post @ W_out + b_out