### PR TITLE
Fix to include ln_final.w in RMSNorm hook

### DIFF
--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -336,8 +336,8 @@ class RMSNorm(nn.Module):
         scale: Float[torch.Tensor, "batch pos 1"] = self.hook_scale(
             (x.pow(2).mean(-1, keepdim=True) + self.eps).sqrt()
         )
-        x = self.hook_normalized(x / scale).to(self.cfg.dtype)  # [batch, pos, length]
-        return x * self.w
+        x = x / scale  # [batch, pos, length]
+        return self.hook_normalized(x * self.w).to(self.cfg.dtype)
 
 
 # Attention


### PR DESCRIPTION
# Description

Before fix, `model_cache["ln_final.hook_normalized"]` will only return the RMS normalized hidden states without multiplying the `final_ln` weight. This might contractict with the design of this hook. I followed the implementation in LayerNorm hook to include `self.w` into the `hook_normalized` hookpoint.

I have currently found no issues related to this. Hope this helps :)

## Before Fix
```python
def forward(
        self, x: Float[torch.Tensor, "batch pos length"]
    ) -> Float[torch.Tensor, "batch pos length"]:
        if self.cfg.dtype not in [torch.float32, torch.float64]:
            x = x.to(torch.float32)

        scale: Float[torch.Tensor, "batch pos 1"] = self.hook_scale(
            (x.pow(2).mean(-1, keepdim=True) + self.eps).sqrt()
        )
        x = self.hook_normalized(x / scale).to(self.cfg.dtype)  # [batch, pos, length]
        return x * self.w
```

## After Fix
```python
def forward(
        self, x: Float[torch.Tensor, "batch pos length"]
    ) -> Float[torch.Tensor, "batch pos length"]:
        if self.cfg.dtype not in [torch.float32, torch.float64]:
            x = x.to(torch.float32)

        scale: Float[torch.Tensor, "batch pos 1"] = self.hook_scale(
            (x.pow(2).mean(-1, keepdim=True) + self.eps).sqrt()
        )
        x = x / scale  # [batch, pos, length]
        return self.hook_normalized(x * self.w).to(self.cfg.dtype)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility