### PR TITLE
Fix llama tokenizer issue with tokenizer-based control of bos prepending

### DIFF
--- a/tests/unit/test_prepend_bos.py
+++ b/tests/unit/test_prepend_bos.py
@@ -1,5 +1,4 @@
 import pytest
-import torch
 from transformers import AutoTokenizer
 
 from transformer_lens import HookedTransformer

--- a/tests/unit/test_prepend_bos.py
+++ b/tests/unit/test_prepend_bos.py
@@ -1,4 +1,6 @@
 import pytest
+import torch
+from transformers import AutoTokenizer
 
 from transformer_lens import HookedTransformer
 
@@ -8,12 +10,11 @@ class TestPrependBos:
 
     # helper functions
     def get_num_tokens_in_prompt(self, model, prompt, intended_prepend_bos):
-        tokenizer = model.tokenizer
-
-        # copied from HookedTransformer.to_tokens()
+        tokenizer = AutoTokenizer.from_pretrained(
+            model.tokenizer.name_or_path, add_bos_token=False
+        )
         tokens = tokenizer(
             prompt,
-            add_special_tokens=model.cfg.add_special_tokens,
         )["input_ids"]
 
         return len(tokens) + int(intended_prepend_bos)

--- a/tests/unit/test_tokenizer_dict.py
+++ b/tests/unit/test_tokenizer_dict.py
@@ -1,5 +1,4 @@
 import pytest
-import torch
 from transformers import AutoTokenizer
 
 from transformer_lens import HookedTransformer

--- a/tests/unit/test_tokenizer_dict.py
+++ b/tests/unit/test_tokenizer_dict.py
@@ -1,0 +1,157 @@
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+from transformer_lens import HookedTransformer
+
+
+class TestTokenizerDict:
+    prompt = "Hello world!"
+    prompts = ["Italy is in Europe.", "Seoul is the capital of South Korea."]
+
+    # helper functions
+    def get_num_tokens_in_prompt(self, model, prompt, intended_prepend_bos):
+        tokenizer = AutoTokenizer.from_pretrained(
+            model.tokenizer.name_or_path, add_bos_token=False
+        )
+        tokens = tokenizer(
+            prompt,
+        )["input_ids"]
+
+        return len(tokens) + int(intended_prepend_bos)
+
+    def check_first_token(self, model, str_tokens, tokens, intended_prepend_bos):
+        if intended_prepend_bos:
+            assert str_tokens[0] == model.tokenizer.bos_token
+            assert tokens[0][0] == model.tokenizer.bos_token_id
+        else:
+            assert str_tokens[0] != model.tokenizer.bos_token
+            assert tokens[0][0] != model.tokenizer.bos_token_id
+
+    def check_tokens_length(
+        self, model, logits, str_tokens, tokens, intended_prepend_bos
+    ):
+        expected_num_tokens = self.get_num_tokens_in_prompt(
+            model, self.prompt, intended_prepend_bos
+        )
+        assert (
+            logits.shape[1] == len(str_tokens) == tokens.shape[1] == expected_num_tokens
+        )
+
+    def check_prompt(self, model, intended_prepend_bos, overriding_prepend_bos=None):
+        logits = model(
+            self.prompt, prepend_bos=overriding_prepend_bos
+        )  # [batch pos d_vocab]
+        str_tokens = model.to_str_tokens(
+            self.prompt, prepend_bos=overriding_prepend_bos
+        )
+        tokens = model.to_tokens(self.prompt, prepend_bos=overriding_prepend_bos)
+
+        self.check_first_token(model, str_tokens, tokens, intended_prepend_bos)
+        self.check_tokens_length(
+            model, logits, str_tokens, tokens, intended_prepend_bos
+        )
+
+    def check_prompts(
+        self,
+        model,
+        intended_prepend_bos,
+        intended_padding_side,
+        overriding_prepend_bos=None,
+        overriding_padding_side=None,
+    ):
+        tokens = model.to_tokens(
+            self.prompts,
+            prepend_bos=intended_prepend_bos,
+            padding_side=intended_padding_side,
+        )
+        if intended_padding_side == "left":
+            if model.tokenizer.pad_token_id != model.tokenizer.bos_token_id:
+                assert (tokens[:, 0] == model.tokenizer.pad_token_id).sum() == 1, tokens
+                assert (tokens[:, 0] == model.tokenizer.bos_token_id).sum() == (
+                    1 if intended_prepend_bos else 0
+                ), tokens
+            else:
+                assert (tokens[:, 0] == model.tokenizer.pad_token_id).sum() == (
+                    tokens.shape[0] if intended_prepend_bos else 1
+                ), tokens
+        else:
+            assert (tokens[:, -1] == model.tokenizer.pad_token_id).sum() == 1, tokens
+            if intended_prepend_bos:
+                assert (tokens[:, 0] == model.tokenizer.bos_token_id).all(), tokens
+
+        if model.tokenizer.pad_token_id != model.tokenizer.bos_token_id:
+            if intended_prepend_bos:
+                assert (tokens == model.tokenizer.bos_token_id).sum() == tokens.shape[
+                    0
+                ], tokens
+            else:
+                assert (tokens == model.tokenizer.bos_token_id).sum() == 0, tokens
+
+    # fixtures
+    @pytest.fixture(
+        scope="class",
+        params=["gpt2-small", "facebook/opt-125m", "EleutherAI/pythia-14m"],
+    )
+    def model_name(self, request):
+        return request.param
+
+    @pytest.fixture(scope="class")
+    def model(self, model_name):
+        model = HookedTransformer.from_pretrained(model_name)
+        return model
+
+    # tests
+    def test_defaults(self, model_name):
+        intended_prepend_bos, intended_padding_side = True, "right"
+        model = HookedTransformer.from_pretrained(model_name)
+
+        assert (
+            model.cfg.default_prepend_bos == intended_prepend_bos
+        ), "Default prepend_bos should be True"
+        assert (
+            model.default_padding_side == intended_padding_side
+        ), "Default padding_side should be right"
+
+        self.check_prompt(model, intended_prepend_bos)
+        self.check_prompts(model, intended_prepend_bos, intended_padding_side)
+
+    def test_given_defaults(self, model_name):
+        intended_prepend_bos, intended_padding_side = False, "left"
+        model = HookedTransformer.from_pretrained(
+            model_name, default_prepend_bos=intended_prepend_bos
+        )
+        if model.tokenizer is None:
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            tokenizer.padding_side = intended_padding_side
+            model.tokenizer = tokenizer
+        else:
+            model.tokenizer.padding_side = intended_padding_side
+
+        self.check_prompt(model, intended_prepend_bos)
+        self.check_prompts(model, intended_prepend_bos, intended_padding_side)
+
+    @pytest.mark.parametrize("intended_prepend_bos", [True, False])
+    @pytest.mark.parametrize("intended_padding_side", ["left", "right"])
+    def test_changing_defaults(
+        self, model, intended_prepend_bos, intended_padding_side
+    ):
+        model.default_padding_side = intended_padding_side
+        model.cfg.default_prepend_bos = intended_prepend_bos
+
+        self.check_prompt(model, intended_prepend_bos)
+        self.check_prompts(model, intended_prepend_bos, intended_padding_side)
+
+    @pytest.mark.parametrize("intended_prepend_bos", [True, False])
+    @pytest.mark.parametrize("intended_padding_side", ["left", "right"])
+    def test_overriding_defaults(
+        self, model, intended_prepend_bos, intended_padding_side
+    ):
+        self.check_prompt(model, intended_prepend_bos, intended_prepend_bos)
+        self.check_prompts(
+            model,
+            intended_prepend_bos,
+            intended_padding_side,
+            intended_prepend_bos,
+            intended_padding_side,
+        )

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -598,7 +598,7 @@ class HookedTransformer(HookedRootModule):
             assert (
                 self.tokenizer is not None
             ), "Cannot use to_tokens without a tokenizer"
-            
+
             tokens = self.tokenizer(
                 input,
                 return_tensors="pt",

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -493,6 +493,9 @@ class HookedTransformer(HookedRootModule):
 
     def ensure_consistent_default_padding_side(self):
         tokenizer = self.tokenizer_dict[self.cfg.default_prepend_bos]
+        if tokenizer is None:
+            return
+
         if (
             self.tokenizer_dict[not self.cfg.default_prepend_bos].padding_side
             != tokenizer.padding_side

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -182,7 +182,6 @@ class HookedTransformerConfig:
     gated_mlp: bool = False
     default_prepend_bos: bool = True
     dtype: torch.dtype = torch.float32
-    add_special_tokens: Optional[bool] = None  # will be set by set_tokenizer
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/tokenization_utils.py
+++ b/transformer_lens/tokenization_utils.py
@@ -1,0 +1,103 @@
+import types
+from copy import deepcopy
+from typing import Iterable, List, Optional, Union
+
+from transformers import AutoTokenizer
+
+
+def set_special_tokens(
+    tokenizer,
+):
+    if tokenizer.eos_token is None:
+        tokenizer.add_special_tokens({"eos_token": "<|endoftext|>"})
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    if tokenizer.bos_token is None:
+        tokenizer.bos_token = tokenizer.eos_token
+
+    return tokenizer
+
+
+def get_tokenizer_with_manually_prepended_bos(tokenizer):
+    def get_bos_prepended_input(input):
+        if isinstance(input, str):
+            return tokenizer.bos_token + input
+        elif isinstance(input, Iterable):
+            return [get_bos_prepended_input(i) for i in input]
+        else:
+            raise ValueError(f"Unsupported input type: {type(input)}")
+
+    def encode_plus(
+        self,
+        text: Union[str, List[str]],
+        text_pair: Optional[Union[str, List[str]]] = None,
+        *args,
+        **kwargs,
+    ):
+        text = get_bos_prepended_input(text)
+        if text_pair:
+            text_pair = get_bos_prepended_input(text_pair)
+        return self.__encode_plus(text, text_pair, *args, **kwargs)
+
+    def batch_encode_plus(
+        self,
+        batch_text_or_text_pairs,
+        *args,
+        **kwargs,
+    ):
+        batch_text_or_text_pairs = get_bos_prepended_input(batch_text_or_text_pairs)
+        return self.__batch_encode_plus(batch_text_or_text_pairs, *args, **kwargs)
+
+    tokenizer = deepcopy(tokenizer)
+
+    # Monkey patch the tokenizer to manually prepend the bos token
+    if not hasattr(tokenizer, "__encode_plus"):
+        tokenizer.__encode_plus = tokenizer.encode_plus
+        tokenizer.encode_plus = types.MethodType(encode_plus, tokenizer)
+        tokenizer.__batch_encode_plus = tokenizer.batch_encode_plus
+        tokenizer.batch_encode_plus = types.MethodType(batch_encode_plus, tokenizer)
+
+    return tokenizer
+
+
+def get_tokenizer_dict(tokenizer):
+    init_kwargs = deepcopy(tokenizer.init_kwargs)
+    pretrained_model_name_or_path = init_kwargs.pop("name_or_path")
+    add_bos_token = init_kwargs.pop("add_bos_token", None)
+    if add_bos_token is None:
+        add_bos_token = getattr(tokenizer, "add_bos_token", False)
+
+    if add_bos_token:
+        tokenizer_with_bos = tokenizer
+        tokenizer_without_bos = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, add_bos_token=False, **init_kwargs
+        )
+    else:
+        tokenizer_without_bos = tokenizer
+        tokenizer_with_bos = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, add_bos_token=True, **init_kwargs
+        )
+
+    tokenizer_with_bos = set_special_tokens(
+        tokenizer_with_bos,
+    )
+    tokenizer_without_bos = set_special_tokens(
+        tokenizer_without_bos,
+    )
+
+    # If the tokenizer doesn't automatically prepend a bos token
+    # with add_bos_token=True, we need to manually prepend it
+    if tokenizer_with_bos.encode("") == tokenizer_without_bos.encode(""):
+        if len(tokenizer_with_bos.encode("")) == 0:
+            tokenizer_with_bos = get_tokenizer_with_manually_prepended_bos(
+                tokenizer_with_bos
+            )
+        else:
+            raise ValueError(
+                "tokenizer_without_bos canoot be properly set for this tokenizer."
+            )
+
+    return {
+        True: tokenizer_with_bos,
+        False: tokenizer_without_bos,
+    }


### PR DESCRIPTION
# Description

This PR changes the mechanism of `prepend_bos` to dynamically switch between two tokenizers (one that prepends bos and one that does not prepend bos) following the philosophy of huggingface tokenizers that "once a tokenizer is saved, we should not change it again, but rather re-convert it" described in https://github.com/huggingface/transformers/issues/25886#issuecomment-1701013725.

Previously, if we wanted to prepend a bos token to the input, we manually added it to the input, e.g., `self.tokenizer.bos_token + input`. However, this resulted in a bug for LLaMA tokenizers because they behave differently when the bos token is manually prepended and it is automatically prepended by the tokenizer. (https://github.com/neelnanda-io/TransformerLens/issues/373#issuecomment-1701017935)

While the interface for the user remains the same, this PR changes the internal mechanism of prepending bos to holding two tokenizers in `self.tokenizer_dict`, one that prepends bos to the input and one that does not prepend bos. The user can just provide the model one tokenizer; the code detects whether the given tokenizer uses bos by default and then creates the counterpart. Which tokenizer to use is controlled by the value set in `model.cfg.default_prepend_bos`. If `model.cfg.default_prepend_bos=True`, `self.tokenizer` forwards to `self.tokenizer_dict[True]` which prepends pos. Local overriding by calling string preprocessing methods like `to_tokens(text, prepend_bos=False)` is also supported. The code also handles the local/global changes in `padding_side` so that `padding_side` of the two tokenizers remains synced even if the user changes it.

One caveat in the current state of PR is that I monkey-patched the tokenizer when the tokenizer does not originally use a bos token and we need to add it manually. I did this in order to use the same interface for the two tokenizers, but I am aware that this approach is potentially dangerous. I just couldn't think of a better way by myself. I am open to better solutions/suggestions.

I checked that things work as expected with `test_tokenizer_dict.py`. I didn't add models like llama-7b or gpt-j-6b to the tests because the models are too large, but I've manually run the test code using those models as well and checked that there's no issue.

Fixes https://github.com/neelnanda-io/TransformerLens/issues/373#issuecomment-1701017935

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility