### PR TITLE
Fix llama tokenization issue by using tokenizer initialized with add_bos_token=True

### DIFF
--- a/tests/unit/test_only_tokenizer.py
+++ b/tests/unit/test_only_tokenizer.py
@@ -1,0 +1,269 @@
+import logging
+from typing import Dict
+
+import pytest
+from transformers import AutoTokenizer
+
+import transformer_lens.loading_from_pretrained as loading
+from transformer_lens import HookedTransformer, HookedTransformerConfig
+
+
+class TokenizerOnlyHookedTransformer(HookedTransformer):
+    def __init__(
+        self,
+        cfg,
+        tokenizer=None,
+        move_to_device=True,
+        default_padding_side="right",
+    ):
+        if isinstance(cfg, Dict):
+            cfg = HookedTransformerConfig(**cfg)
+        elif isinstance(cfg, str):
+            raise ValueError(
+                "Please pass in a config dictionary or HookedTransformerConfig object. If you want to load a "
+                "pretrained model, use HookedTransformer.from_pretrained() instead."
+            )
+        self.cfg = cfg
+
+        if tokenizer is not None:
+            self.set_tokenizer(tokenizer, default_padding_side=default_padding_side)
+        elif self.cfg.tokenizer_name is not None:
+            # If we have a tokenizer name, we can load it from HuggingFace
+            self.set_tokenizer(
+                AutoTokenizer.from_pretrained(
+                    self.cfg.tokenizer_name, add_bos_token=True
+                ),
+                default_padding_side=default_padding_side,
+            )
+        else:
+            # If no tokenizer name is provided, we assume we're training on an algorithmic task and will pass in tokens
+            # directly. In this case, we don't need a tokenizer.
+            assert (
+                self.cfg.d_vocab != -1
+            ), "Must provide a tokenizer if d_vocab is not provided"
+            self.tokenizer = None
+            if default_padding_side != "right":
+                logging.warning(
+                    "default_padding_side is explictly given but ignored because tokenizer is not set."
+                )
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name: str,
+        fold_ln=True,
+        center_writing_weights=True,
+        center_unembed=True,
+        refactor_factored_attn_matrices=False,
+        checkpoint_index=None,
+        checkpoint_value=None,
+        hf_model=None,
+        device=None,
+        n_devices=1,
+        tokenizer=None,
+        move_to_device=True,
+        fold_value_biases=True,
+        default_prepend_bos=True,
+        default_padding_side="right",
+        **from_pretrained_kwargs,
+    ) -> "TokenizerOnlyHookedTransformer":
+        # Get the model name used in HuggingFace, rather than the alias.
+        official_model_name = loading.get_official_model_name(model_name)
+
+        # Load the config into an HookedTransformerConfig object. If loading from a
+        # checkpoint, the config object will contain the information about the
+        # checkpoint
+        cfg = loading.get_pretrained_model_config(
+            official_model_name,
+            checkpoint_index=checkpoint_index,
+            checkpoint_value=checkpoint_value,
+            fold_ln=fold_ln,
+            device=device,
+            n_devices=n_devices,
+            default_prepend_bos=default_prepend_bos,
+            **from_pretrained_kwargs,
+        )
+
+        # Create the HookedTransformer object
+        model = cls(
+            cfg,
+            tokenizer,
+            move_to_device=False,
+            default_padding_side=default_padding_side,
+        )
+
+        return model
+
+
+class TestTokenizer:
+    prompt = "Hello world!"
+    prompts = ["Italy is in Europe.", "Seoul is the capital of South Korea."]
+
+    # helper functions
+    def get_num_tokens_in_prompt(self, model, prompt, intended_prepend_bos):
+        tokenizer = AutoTokenizer.from_pretrained(
+            model.tokenizer.name_or_path, add_bos_token=False
+        )
+        tokens = tokenizer(
+            prompt,
+        )["input_ids"]
+
+        return len(tokens) + int(intended_prepend_bos)
+
+    def check_first_token(self, model, str_tokens, tokens, intended_prepend_bos):
+        if intended_prepend_bos:
+            assert str_tokens[0] == model.tokenizer.bos_token
+            assert tokens[0][0] == model.tokenizer.bos_token_id
+        else:
+            assert str_tokens[0] != model.tokenizer.bos_token
+            assert tokens[0][0] != model.tokenizer.bos_token_id
+
+    def check_tokens_length(self, model, str_tokens, tokens, intended_prepend_bos):
+        expected_num_tokens = self.get_num_tokens_in_prompt(
+            model, self.prompt, intended_prepend_bos
+        )
+
+        assert len(str_tokens) == tokens.shape[1] == expected_num_tokens
+
+    def check_prompt(self, model, intended_prepend_bos, overriding_prepend_bos=None):
+        str_tokens = model.to_str_tokens(
+            self.prompt, prepend_bos=overriding_prepend_bos
+        )
+        tokens = model.to_tokens(self.prompt, prepend_bos=overriding_prepend_bos)
+
+        self.check_first_token(model, str_tokens, tokens, intended_prepend_bos)
+        self.check_tokens_length(model, str_tokens, tokens, intended_prepend_bos)
+
+    def check_prompts(
+        self,
+        model,
+        intended_prepend_bos,
+        intended_padding_side,
+        overriding_prepend_bos=None,
+        overriding_padding_side=None,
+    ):
+        tokens = model.to_tokens(
+            self.prompts,
+            prepend_bos=overriding_prepend_bos,
+            padding_side=overriding_padding_side,
+        )
+        if intended_padding_side == "left":
+            if model.tokenizer.pad_token_id != model.tokenizer.bos_token_id:
+                assert (tokens[:, 0] == model.tokenizer.pad_token_id).sum() == 1, tokens
+                assert (tokens[:, 0] == model.tokenizer.bos_token_id).sum() == (
+                    1 if intended_prepend_bos else 0
+                ), tokens
+            else:
+                assert (tokens[:, 0] == model.tokenizer.pad_token_id).sum() == (
+                    tokens.shape[0] if intended_prepend_bos else 1
+                ), tokens
+        else:
+            assert (tokens[:, -1] == model.tokenizer.pad_token_id).sum() == 1, tokens
+            if intended_prepend_bos:
+                assert (tokens[:, 0] == model.tokenizer.bos_token_id).all(), tokens
+
+        if model.tokenizer.pad_token_id != model.tokenizer.bos_token_id:
+            if intended_prepend_bos:
+                assert (tokens == model.tokenizer.bos_token_id).sum() == tokens.shape[
+                    0
+                ], tokens
+            else:
+                assert (tokens == model.tokenizer.bos_token_id).sum() == 0, tokens
+
+    # fixtures
+    @pytest.fixture(
+        scope="class",
+        params=[
+            "gpt2-small",
+            "facebook/opt-125m",
+            "EleutherAI/pythia-14m",
+            "EleutherAI/gpt-j-6b",
+        ],
+    )
+    def model_name(self, request):
+        return request.param
+
+    @pytest.fixture(scope="class")
+    def model(self, model_name):
+        model = TokenizerOnlyHookedTransformer.from_pretrained(model_name)
+        return model
+
+    # tests
+    def test_defaults(self, model_name):
+        intended_prepend_bos, intended_padding_side = True, "right"
+        model = TokenizerOnlyHookedTransformer.from_pretrained(model_name)
+
+        assert (
+            model.cfg.default_prepend_bos == intended_prepend_bos
+        ), "Default prepend_bos should be True"
+        assert (
+            model.tokenizer.padding_side == intended_padding_side
+        ), "Default padding_side should be right"
+
+        self.check_prompt(model, intended_prepend_bos)
+        self.check_prompts(model, intended_prepend_bos, intended_padding_side)
+
+    def test_given_defaults(self, model_name):
+        intended_prepend_bos, intended_padding_side = False, "left"
+        model = TokenizerOnlyHookedTransformer.from_pretrained(
+            model_name, default_prepend_bos=intended_prepend_bos
+        )
+        if model.tokenizer is None:
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            tokenizer.padding_side = intended_padding_side
+            model.tokenizer = tokenizer
+        else:
+            model.tokenizer.padding_side = intended_padding_side
+
+        self.check_prompt(model, intended_prepend_bos)
+        self.check_prompts(model, intended_prepend_bos, intended_padding_side)
+
+    @pytest.mark.parametrize("intended_prepend_bos", [True, False])
+    @pytest.mark.parametrize("intended_padding_side", ["left", "right"])
+    def test_changing_defaults(
+        self, model, intended_prepend_bos, intended_padding_side
+    ):
+        model.tokenizer.padding_side = intended_padding_side
+        model.cfg.default_prepend_bos = intended_prepend_bos
+
+        self.check_prompt(model, intended_prepend_bos)
+        self.check_prompts(model, intended_prepend_bos, intended_padding_side)
+
+    @pytest.mark.parametrize("intended_prepend_bos", [True, False])
+    @pytest.mark.parametrize("intended_padding_side", ["left", "right"])
+    def test_overriding_defaults(
+        self, model, intended_prepend_bos, intended_padding_side
+    ):
+        self.check_prompt(model, intended_prepend_bos, intended_prepend_bos)
+        self.check_prompts(
+            model,
+            intended_prepend_bos,
+            intended_padding_side,
+            intended_prepend_bos,
+            intended_padding_side,
+        )
+
+    def test_same_tokenization(self, model):
+        prompt = self.prompt
+        prompts = [
+            "Italy is in Europe.",
+            "Pyeongchang Olympics was held in 2018",
+            "2023-09-09",
+            "287594812673495",
+        ]
+
+        model.tokenizer.padding_side = "right"
+
+        for input in [prompt, prompts]:
+            tokens_with_bos = model.to_tokens(input, prepend_bos=True)
+            tokens_without_bos = model.to_tokens(input, prepend_bos=False)
+            assert tokens_with_bos[..., 1:].equal(tokens_without_bos)
+
+            str_tokens_with_bos = model.to_str_tokens(input, prepend_bos=True)
+            str_tokens_without_bos = model.to_str_tokens(input, prepend_bos=False)
+
+            if isinstance(str_tokens_with_bos[0], list):
+                for i in range(len(str_tokens_with_bos)):
+                    assert str_tokens_with_bos[i][1:] == str_tokens_without_bos[i]
+            else:
+                assert str_tokens_with_bos[1:] == str_tokens_without_bos

--- a/tests/unit/test_prepend_bos.py
+++ b/tests/unit/test_prepend_bos.py
@@ -125,3 +125,28 @@ class TestPrependBos:
             model.tokenizer.bos_token_id, self.prompt, prepend_bos=True
         )
         assert bos_position == 0
+
+    def test_same_tokenization(self, model):
+        prompt = self.prompt
+        prompts = [
+            "Italy is in Europe.",
+            "Pyeongchang Olympics was held in 2018",
+            "2023-09-09",
+            "287594812673495",
+        ]
+
+        model.tokenizer.padding_side = "right"
+
+        for input in [prompt, prompts]:
+            tokens_with_bos = model.to_tokens(input, prepend_bos=True)
+            tokens_without_bos = model.to_tokens(input, prepend_bos=False)
+            assert tokens_with_bos[..., 1:].equal(tokens_without_bos)
+            
+            str_tokens_with_bos = model.to_str_tokens(input, prepend_bos=True)
+            str_tokens_without_bos = model.to_str_tokens(input, prepend_bos=False)
+            
+            if isinstance(str_tokens_with_bos[0], list):
+                for i in range(len(str_tokens_with_bos)):
+                    assert str_tokens_with_bos[i][1:] == str_tokens_without_bos[i]
+            else:
+                assert str_tokens_with_bos[1:] == str_tokens_without_bos

--- a/tests/unit/test_prepend_bos.py
+++ b/tests/unit/test_prepend_bos.py
@@ -1,4 +1,5 @@
 import pytest
+from transformers import AutoTokenizer
 
 from transformer_lens import HookedTransformer
 
@@ -8,12 +9,11 @@ class TestPrependBos:
 
     # helper functions
     def get_num_tokens_in_prompt(self, model, prompt, intended_prepend_bos):
-        tokenizer = model.tokenizer
-
-        # copied from HookedTransformer.to_tokens()
+        tokenizer = AutoTokenizer.from_pretrained(
+            model.tokenizer.name_or_path, add_bos_token=False
+        )
         tokens = tokenizer(
             prompt,
-            add_special_tokens=model.cfg.add_special_tokens,
         )["input_ids"]
 
         return len(tokens) + int(intended_prepend_bos)

--- a/tests/unit/test_prepend_bos.py
+++ b/tests/unit/test_prepend_bos.py
@@ -141,10 +141,10 @@ class TestPrependBos:
             tokens_with_bos = model.to_tokens(input, prepend_bos=True)
             tokens_without_bos = model.to_tokens(input, prepend_bos=False)
             assert tokens_with_bos[..., 1:].equal(tokens_without_bos)
-            
+
             str_tokens_with_bos = model.to_str_tokens(input, prepend_bos=True)
             str_tokens_without_bos = model.to_str_tokens(input, prepend_bos=False)
-            
+
             if isinstance(str_tokens_with_bos[0], list):
                 for i in range(len(str_tokens_with_bos)):
                     assert str_tokens_with_bos[i][1:] == str_tokens_without_bos[i]

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1048,6 +1048,8 @@ class HookedTransformer(HookedRootModule):
         center_unembed=False,
         refactor_factored_attn_matrices=False,
         fold_value_biases=False,
+        default_prepend_bos=True,
+        default_padding_side="right",
         **from_pretrained_kwargs,
     ):
         """Wrapper for from_pretrained with all boolean flags related to simplifying the model set to False. Refer to
@@ -1059,6 +1061,8 @@ class HookedTransformer(HookedRootModule):
             center_unembed=center_unembed,
             fold_value_biases=fold_value_biases,
             refactor_factored_attn_matrices=refactor_factored_attn_matrices,
+            default_prepend_bos=default_prepend_bos,
+            default_padding_side=default_padding_side,
             **from_pretrained_kwargs,
         )
 

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -92,9 +92,7 @@ class HookedTransformer(HookedRootModule):
             # If we have a tokenizer name, we can load it from HuggingFace
             if "llama" in self.cfg.tokenizer_name.lower():
                 # llama tokenizer requires special handling
-                logging.warning(
-                    "LLaMA tokenizer not loaded. Please load manually."
-                )
+                logging.warning("LLaMA tokenizer not loaded. Please load manually.")
             else:
                 self.set_tokenizer(
                     AutoTokenizer.from_pretrained(

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -92,10 +92,14 @@ class HookedTransformer(HookedRootModule):
             # If we have a tokenizer name, we can load it from HuggingFace
             if "llama" in self.cfg.tokenizer_name.lower():
                 # llama tokenizer requires special handling
-                print("Warning: LLaMA tokenizer not loaded. Please load manually.")
+                logging.warning(
+                    "LLaMA tokenizer not loaded. Please load manually."
+                )
             else:
                 self.set_tokenizer(
-                    AutoTokenizer.from_pretrained(self.cfg.tokenizer_name),
+                    AutoTokenizer.from_pretrained(
+                        self.cfg.tokenizer_name, add_bos_token=True
+                    ),
                     default_padding_side=default_padding_side,
                 )
         else:
@@ -105,6 +109,10 @@ class HookedTransformer(HookedRootModule):
                 self.cfg.d_vocab != -1
             ), "Must provide a tokenizer if d_vocab is not provided"
             self.tokenizer = None
+            if default_padding_side != "right":
+                logging.warning(
+                    "default_padding_side is explictly given but ignored because tokenizer is not set."
+                )
 
         self.embed = Embed(self.cfg)
         self.hook_embed = HookPoint()  # [batch, pos, d_model]
@@ -493,13 +501,32 @@ class HookedTransformer(HookedRootModule):
     ):
         """
         Sets the tokenizer to use for this model.
-        tokenizer (PreTrainedTokenizer): a pretrained HuggingFace tokenizer
-        default_padding_side (str): "right" or "left", which side to pad on
+
+        Args:
+            tokenizer (PreTrainedTokenizer): a pretrained HuggingFace tokenizer
+            default_padding_side (str): "right" or "left", which side to pad on
         """
         assert isinstance(
             tokenizer, PreTrainedTokenizerBase
         ), f"{type(tokenizer)} is not a supported tokenizer, please use PreTrainedTokenizer or PreTrainedTokenizerFast"
-        self.tokenizer = tokenizer
+
+        assert default_padding_side in [
+            "right",
+            "left",
+        ], f"padding_side must be 'right' or 'left', got {default_padding_side}"
+
+        # Use a tokenizer that is initialized with add_bos_token=True as the default tokenizer.
+        # Such a tokenizer should be set as the default tokenizer because the tokenization of some
+        # tokenizers like LlamaTokenizer are different when bos token is automatically/manually
+        # prepended, and add_bos_token cannot be dynamically controlled after initialization
+        # (https://github.com/huggingface/transformers/issues/25886).
+        tokenizer_with_bos = utils.get_tokenizer_with_bos(tokenizer)
+        self.tokenizer = tokenizer_with_bos
+        self.tokenizer.padding_side = default_padding_side
+
+        # Some tokenizers doesn't automatically prepend the BOS token even when they are initialized
+        # with add_bos_token=True. Therefore, we need this information to dynamically control prepend_bos.
+        self.cfg.tokenizer_prepends_bos = len(self.tokenizer.encode("")) > 0
 
         if self.tokenizer.eos_token is None:
             self.tokenizer.eos_token = "<|endoftext|>"
@@ -513,19 +540,6 @@ class HookedTransformer(HookedRootModule):
             self.cfg.d_vocab = max(self.tokenizer.vocab.values()) + 1
         if self.cfg.d_vocab_out == -1:
             self.cfg.d_vocab_out = self.cfg.d_vocab
-
-        assert default_padding_side in [
-            "right",
-            "left",
-        ], f"padding_side must be 'right' or 'left', got {default_padding_side}"
-        self.tokenizer.padding_side = default_padding_side
-
-        # If the tokenizer prepends the BOS token to the input by default, turn it off.
-        # We manually control whether or not to prepend BOS tokens.
-        self.cfg.add_special_tokens = not (
-            len(self.tokenizer("")["input_ids"]) > 0
-            and self.tokenizer("")["input_ids"][0] == self.tokenizer.bos_token_id
-        )
 
     def to_tokens(
         self,
@@ -564,22 +578,27 @@ class HookedTransformer(HookedRootModule):
                 self.tokenizer is not None
             ), "Cannot use to_tokens without a tokenizer"
             assert (
-                self.cfg.add_special_tokens is not None
+                self.cfg.tokenizer_prepends_bos is not None
             ), "Set the tokenizer for the model by calling set_tokenizer"
 
-            if self.cfg.default_prepend_bos:
-                if isinstance(input, str):
-                    input = self.tokenizer.bos_token + input
-                else:
-                    input = [self.tokenizer.bos_token + string for string in input]
+            if self.cfg.default_prepend_bos and not self.cfg.tokenizer_prepends_bos:
+                # We want to prepend bos but the tokenizer doesn't automatically do it, so we add it manually
+                input = utils.get_input_with_manually_prepended_bos(
+                    self.tokenizer, input
+                )
+
             tokens = self.tokenizer(
                 input,
                 return_tensors="pt",
                 padding=True,
                 truncation=truncate,
                 max_length=self.cfg.n_ctx if truncate else None,
-                add_special_tokens=self.cfg.add_special_tokens,
             )["input_ids"]
+
+            if not self.cfg.default_prepend_bos and self.cfg.tokenizer_prepends_bos:
+                # We don't want to prepend bos but the tokenizer does it automatically, so we remove it manually
+                tokens = utils.get_tokens_with_bos_removed(self.tokenizer, tokens)
+
             if move_to_device:
                 tokens = tokens.to(self.cfg.device)
             return tokens

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -137,6 +137,9 @@ class HookedTransformerConfig:
             default_prepend_bos=False. Note that you can also locally override the default behavior by passing
             in prepend_bos=True/False when you call a method that processes the input string.
         dtype (torch.dtype, *optional*): The model's dtype. Defaults to torch.float32.
+        tokenizer_prepends_bos (bool, *optional*): This flag is set by set_tokenizer. It is set to True only
+            when the tokenizer automatically prepends the BOS token if initialized with add_bos_token=True.
+            We need this information to dynamically control bos prepending.
     """
 
     n_layers: int
@@ -182,7 +185,7 @@ class HookedTransformerConfig:
     gated_mlp: bool = False
     default_prepend_bos: bool = True
     dtype: torch.dtype = torch.float32
-    add_special_tokens: Optional[bool] = None  # will be set by set_tokenizer
+    tokenizer_prepends_bos: Optional[bool] = None
 
     def __post_init__(self):
         if self.n_heads == -1:


### PR DESCRIPTION
# Description

This PR ensures that the `tokenizer` used by the model is initialized with `add_bos_token=True`.

Previously, the tokenizer that  does not prepend bos was used as default. When we wanted to prepend a bos token to the input, we manually added it to the input, e.g., `tokenizer.bos_token + input`. However, this resulted in a bug for LLaMA tokenizers because they behave differently when the bos token is manually prepended and when it is automatically prepended by the tokenizer (https://github.com/neelnanda-io/TransformerLens/issues/373#issuecomment-1701017935).

It is necessary to ensure that the tokenizer is initialized with `from_pretrained(add_bos_token=True)` because `add_bos_token` cannot be dynamically controlled after initialization (https://github.com/huggingface/transformers/issues/25886).

Because some tokenizers doesn't automatically prepend bos token even when they are initialized with `add_bos_token=True`, `cfg.tokenizer_prepends_bos` is introduced to check if the tokenizer _does_ prepend bos token or not when initialized with `add_bos_token=True`.

The test for tokenizers are in `test_only_tokenizer.py`. (I also manually tested llama tokenizer using the same test.)

Fixes https://github.com/neelnanda-io/TransformerLens/issues/373

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility