### PR TITLE
Implement `hook_mlp_in` for parallel attention/MLP models

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1451,6 +1451,8 @@ class HookedTransformer(HookedRootModule):
         """
         Toggles whether to allow storing and editing inputs to each MLP layer.
         """
+
+        assert not self.cfg.attn_only, "Can't use hook_mlp_in with attn_only model"
         self.cfg.use_hook_mlp_in = use_hook_mlp_in
 
     def process_weights_(

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -1076,7 +1076,11 @@ class TransformerBlock(nn.Module):
         elif self.cfg.parallel_attn_mlp:
             # Dumb thing done by GPT-J, both MLP and Attn read from resid_pre and write to resid_post, no resid_mid used.
             # In GPT-J, LN1 and LN2 are tied, in GPT-NeoX they aren't.
-            normalized_resid_pre_2 = self.ln2(resid_pre)
+            normalized_resid_pre_2 = self.ln2(
+                resid_pre
+                if not self.cfg.use_hook_mlp_in
+                else self.hook_mlp_in(resid_pre.clone())
+            )
             mlp_out = self.hook_mlp_out(
                 self.mlp(normalized_resid_pre_2)
             )  # [batch, pos, d_model]


### PR DESCRIPTION
# Description

Previously `hook_mlp_in` wasn't implemented in parallel attention/MLP models. Oops! I even remembered to add this to BERT...

I also added a check that `hook_mlp_in` is not being used with attention only models.

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility