### PR TITLE
Improve Key-Value Caching

### DIFF
--- a/tests/unit/test_kv_cache.py
+++ b/tests/unit/test_kv_cache.py
@@ -80,3 +80,98 @@ def test_multiple_new_tokens():
     assert t.allclose(
         no_cache_logits[:, -new_tokens_len:], with_cache_logits, atol=1e-3
     )
+
+
+def test_freeze_cache():
+    past_left_attention_mask = utils.get_attention_mask(
+        model.tokenizer,
+        pre_prompt_tokens,
+        model.cfg.default_prepend_bos,
+    )
+
+    post_prompt_1 = " I'm headed to the church to play bingo."
+    new_tokens_1 = model.to_tokens(post_prompt_1, prepend_bos=False)
+    full_prompt_tokens_1 = t.cat([pre_prompt_tokens, new_tokens_1], dim=-1)
+    past_kv_cache_1 = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+
+    post_prompt_2 = " shine your light on me, Miss Liberty"
+    new_tokens_2 = model.to_tokens(post_prompt_2, prepend_bos=False)
+    past_kv_cache_2 = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+
+    model(
+        pre_prompt_tokens,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache_1,
+        past_left_attention_mask=None,
+    )
+    past_kv_cache_1.freeze()
+    with_cache_logits_1 = model(
+        new_tokens_1,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache_1,
+        past_left_attention_mask=past_left_attention_mask,
+    )
+
+    model(
+        pre_prompt_tokens,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache_2,
+        past_left_attention_mask=None,
+    )
+    past_kv_cache_2.freeze()
+    model(
+        new_tokens_2,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache_2,
+        past_left_attention_mask=past_left_attention_mask,
+    )
+
+    # Caches frozen at the same point should be identical
+    assert len(past_kv_cache_1.entries) == len(past_kv_cache_2.entries)
+    for entry_1, entry_2 in zip(past_kv_cache_1.entries, past_kv_cache_2.entries):
+        assert entry_1.past_keys.shape == entry_2.past_keys.shape
+        assert entry_1.past_values.shape == entry_2.past_values.shape
+        assert t.allclose(entry_1.past_keys, entry_2.past_keys, atol=1e-3)
+        assert t.allclose(entry_1.past_values, entry_2.past_values, atol=1e-3)
+
+    # Rerunning the same prompt with a different cache that was frozen at the same
+    # point should give the same results
+    with_cache_2_logits_1 = model(
+        new_tokens_1,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache_2,
+        past_left_attention_mask=past_left_attention_mask,
+    )
+    assert t.allclose(with_cache_logits_1, with_cache_2_logits_1, atol=1e-3)
+
+    # Test unfreeze
+    past_kv_cache_2.unfreeze()
+    with_cache_2_logits_1 = model(
+        new_tokens_1,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache_2,
+        past_left_attention_mask=past_left_attention_mask,
+    )
+    for entry_1, entry_2 in zip(past_kv_cache_1.entries, past_kv_cache_2.entries):
+        assert entry_1.past_keys.shape[1] < entry_2.past_keys.shape[1]
+        assert entry_1.past_values.shape[1] < entry_2.past_values.shape[1]
+
+    # Rerunning the same prompt with a different cache should give different
+    # results
+    assert t.allclose(with_cache_logits_1, with_cache_2_logits_1, atol=1e-3)
+    past_left_attention_mask = utils.get_attention_mask(
+        model.tokenizer,
+        full_prompt_tokens_1,
+        model.cfg.default_prepend_bos,
+    )
+    with_cache_2_logits_1 = model(
+        new_tokens_1,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache_2,
+        past_left_attention_mask=past_left_attention_mask,
+    )
+    assert not t.allclose(with_cache_logits_1, with_cache_2_logits_1, atol=1e-3)

--- a/tests/unit/test_kv_cache.py
+++ b/tests/unit/test_kv_cache.py
@@ -1,0 +1,82 @@
+# %%
+import torch as t
+
+from transformer_lens import HookedTransformer, utils
+from transformer_lens.past_key_value_caching import HookedTransformerKeyValueCache
+
+MODEL = "solu-1l"
+model = HookedTransformer.from_pretrained(MODEL)
+
+pre_prompt = "I went to Staten Island,"
+padding_side = "left"
+prepend_bos = True
+pre_prompt_tokens = model.to_tokens(
+    pre_prompt, prepend_bos=prepend_bos, padding_side=padding_side
+)
+
+
+def test_single_new_token():
+    post_prompt = " Sharon"
+    new_token = model.to_tokens(post_prompt, prepend_bos=False)
+    full_prompt_tokens = t.cat([pre_prompt_tokens, new_token], dim=-1)
+    assert full_prompt_tokens.shape[-1] == pre_prompt_tokens.shape[-1] + 1
+    no_cache_logits = model(full_prompt_tokens, padding_side=padding_side)
+
+    past_kv_cache = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+    model(
+        pre_prompt_tokens,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache,
+        past_left_attention_mask=None,
+    )
+    past_left_attention_mask = utils.get_attention_mask(
+        model.tokenizer,
+        pre_prompt_tokens,
+        model.cfg.default_prepend_bos,
+    )
+    with_cache_logits = model(
+        new_token,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache,
+        past_left_attention_mask=past_left_attention_mask,
+    )
+    print("no_cache_logits", no_cache_logits[:, -1])
+    print("with_cache_logits", with_cache_logits[:, -1])
+    assert t.allclose(no_cache_logits[:, -1], with_cache_logits[:, -1], atol=1e-3)
+    assert t.allclose(no_cache_logits[:, -1:], with_cache_logits, atol=1e-3)
+
+
+def test_multiple_new_tokens():
+    post_prompt = " to buy myself a mandolin"
+    new_tokens = model.to_tokens(post_prompt, prepend_bos=False)
+    new_tokens_len = new_tokens.shape[-1]
+    full_prompt_tokens = t.cat([pre_prompt_tokens, new_tokens], dim=-1)
+    assert full_prompt_tokens.shape[-1] == pre_prompt_tokens.shape[-1] + new_tokens_len
+    no_cache_logits = model(full_prompt_tokens, padding_side=padding_side)
+
+    past_kv_cache = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+    model(
+        pre_prompt_tokens,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache,
+        past_left_attention_mask=None,
+    )
+    past_left_attention_mask = utils.get_attention_mask(
+        model.tokenizer,
+        pre_prompt_tokens,
+        model.cfg.default_prepend_bos,
+    )
+    with_cache_logits = model(
+        new_tokens,
+        padding_side=padding_side,
+        past_kv_cache=past_kv_cache,
+        past_left_attention_mask=past_left_attention_mask,
+    )
+    assert t.allclose(no_cache_logits[:, -1], with_cache_logits[:, -1], atol=1e-3)
+    assert t.allclose(
+        no_cache_logits[:, -new_tokens_len:], with_cache_logits, atol=1e-3
+    )

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -427,10 +427,10 @@ class HookedTransformer(HookedRootModule):
             first transformer block, etc. Supports negative indexing. Useful for analysis of intermediate layers, eg finding
             neuron activations in layer 3 of a 24 layer model. Defaults to None (run the full model).
         past_kv_cache Optional[HookedTransformerKeyValueCache]: If not None, keys and values will be stored for every
-            attention head. If there are keys and values already in the cache, these will be prepended to the keys and values
-            for the new input, so that the new tokens can pay attention to previous tokens. This is useful for generating text,
-            because we don't need to repeat computation for tokens that have already been through the model. Defaults to None
-            (don't use caching).
+            attention head (unless the cache is frozen). If there are keys and values already in the cache, these will be
+            prepended to the keys and values for the new input, so that the new tokens can pay attention to previous tokens.
+            This is useful for generating text, because we don't need to repeat computation for tokens that have already been
+            through the model. Defaults to None (don't use caching).
 
         Note that loss is the standard "predict the next token" cross-entropy loss for GPT-2 style language models -
         if you want a custom loss function, the recommended behaviour is returning the logits and then applying your

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -82,7 +82,7 @@ class PosEmbed(nn.Module):
         self,
         tokens: Int[torch.Tensor, "batch pos"],
         past_kv_pos_offset: int = 0,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        left_attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         """
         Forward pass for positional embeddings.
@@ -532,7 +532,7 @@ class Attention(nn.Module):
         ],
         past_kv_cache_entry: Optional[HookedTransformerKeyValueCacheEntry] = None,
         additive_attention_mask: Optional[Float[torch.Tensor, "batch 1 1 pos"]] = None,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        left_attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         """
         shortformer_pos_embed is only used if self.cfg.positional_embedding_type == "shortformer", else defaults to None and is irrelevant. See HookedTransformerConfig for more details
@@ -661,7 +661,7 @@ class Attention(nn.Module):
             torch.Tensor, "batch head_index pos pos_plus_past_kv_pos_offset"
         ],
         past_kv_pos_offset: int = 0,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        left_attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ):
         # The query context length is the number of positions we take queries from - if not using a past_kv_cache this is just the context length (for the current prompt), but if we're caching it's just a single token.
         query_ctx_length = attn_scores.size(-2)
@@ -1001,7 +1001,7 @@ class TransformerBlock(nn.Module):
             Float[torch.Tensor, "batch pos d_model"]
         ] = None,
         past_kv_cache_entry: Optional[HookedTransformerKeyValueCacheEntry] = None,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        left_attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         """A single Transformer block.
 

--- a/transformer_lens/past_key_value_caching.py
+++ b/transformer_lens/past_key_value_caching.py
@@ -12,6 +12,7 @@ from transformer_lens.utilities.devices import get_device_for_block_index
 class HookedTransformerKeyValueCacheEntry:
     past_keys: Float[torch.Tensor, "batch pos_so_far n_heads d_head"]
     past_values: Float[torch.Tensor, "batch pos_so_far n_heads d_head"]
+    frozen: bool = False
 
     @classmethod
     def init_cache_entry(
@@ -40,8 +41,9 @@ class HookedTransformerKeyValueCacheEntry:
         updated_values: Float[
             torch.Tensor, "batch pos_so_far_plus_new_tokens n_heads d_head"
         ] = torch.cat([self.past_values, new_values], dim=1)
-        self.past_keys = updated_keys
-        self.past_values = updated_values
+        if not self.frozen:
+            self.past_keys = updated_keys
+            self.past_values = updated_values
         return updated_keys, updated_values
 
 
@@ -51,6 +53,8 @@ class HookedTransformerKeyValueCache:
     A cache for storing past keys and values for the Transformer. This is important for generating text - we can cache a lot of past computation and avoid repeating ourselves!
 
     This cache is a list of HookedTransformerKeyValueCacheEntry objects, one for each layer in the Transformer. Each object stores a [batch, pos_so_far, n_heads, d_head] tensor for both keys and values, and each entry has an append method to add a single new key and value.
+
+    The cache can be frozen so that it is not updated during the forward pass. This is useful when we want to run many inputs with the same prefix.
     """
 
     entries: List[HookedTransformerKeyValueCacheEntry]
@@ -72,6 +76,14 @@ class HookedTransformerKeyValueCache:
                 for i in range(cfg.n_layers)
             ]
         )
+
+    def freeze(self):
+        for entry in self.entries:
+            entry.frozen = True
+
+    def unfreeze(self):
+        for entry in self.entries:
+            entry.frozen = False
 
     def __getitem__(self, idx):
         return self.entries[idx]

--- a/transformer_lens/past_key_value_caching.py
+++ b/transformer_lens/past_key_value_caching.py
@@ -51,9 +51,6 @@ class HookedTransformerKeyValueCache:
     A cache for storing past keys and values for the Transformer. This is important for generating text - we can cache a lot of past computation and avoid repeating ourselves!
 
     This cache is a list of HookedTransformerKeyValueCacheEntry objects, one for each layer in the Transformer. Each object stores a [batch, pos_so_far, n_heads, d_head] tensor for both keys and values, and each entry has an append method to add a single new key and value.
-
-    Generation is assumed to be done by initializing with some prompt and then continuing iteratively one token at a time. So append only works for adding a single token's worth of keys and values, and but the cache can be initialized with many.
-
     """
 
     entries: List[HookedTransformerKeyValueCacheEntry]

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -1037,8 +1037,8 @@ class LocallyOverridenDefaults:
             set_nested_attr(self, default_location, default_value)
 
 
-def extend_tensor_with_ones(tensor, dim=1):
+def extend_tensor_with_ones(tensor, dim=1, num_elements=1):
     new_elements = torch.ones(
-        (tensor.shape[0], 1), dtype=tensor.dtype, device=tensor.device
+        (tensor.shape[0], num_elements), dtype=tensor.dtype, device=tensor.device
     )
     return torch.cat([tensor, new_elements], dim=dim)


### PR DESCRIPTION
# Description

Commit 1:
- Support passing in multiple tokens when using `past_kv_cache`.
- Add tests for `past_kv_cache`.
- Add documentation for `past_kv_cache`.
- Fix type hints for some components that assume left_attention_mask has same number of tokens as input. This was previously unnoticed because there were no tests that covered `past_kv_cache`.

Commit 2:
- Support freezing key-value caches.

Commit 3:
- Integrate `past_left_attention_mask` into `HookedTransformerKeyValueCache` so that it doesn't need to managed manually. Remove from `HookedTransformer.forward()`.

## Motivation for allowing multiple tokens to run with key value cache

In ACDC we run the same prompt many times. Patching only affects token positions after the point where the clean and corrupt prompts differ. We want to run the first part of the prompt that is identical between clean and corrupt, freeze the cache, then pass in only the tokens after the point of divergence for our patched runs.

## Breaking change

Commit 3 removes `past_left_attention_mask` from `HookedTransformer.forward()` because the `left_attention_mask` of previous inputs is stored automatically by `HookedTransformerKeyValueCache`. I think this won't break many people's code as this argument was only added 2 weeks ago in #344. And the fix should be quite trivial as it only requires deleting this input. (See changes to tests in commit 3 for an example).

Overall I think the benefits are worth the cost as this makes caching easier to do and generally reduces complexity. I can't think of any case where someone would want to pass in a `past_left_attention_mask` that doesn't match `past_kv_cache`.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility