### PR TITLE
Fix ci neg inf bug

### DIFF
--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -590,13 +590,6 @@ class Attention(nn.Module):
             q = q.to(torch.float32)
             k = k.to(torch.float32)
 
-        result = einsum(
-                "batch query_pos head_index d_head, \
-                    batch key_pos head_index d_head \
-                    -> batch head_index query_pos key_pos",
-                q,
-                k,
-            )
         attn_scores = (
             einsum(
                 "batch query_pos head_index d_head, \

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -590,6 +590,13 @@ class Attention(nn.Module):
             q = q.to(torch.float32)
             k = k.to(torch.float32)
 
+        result = einsum(
+                "batch query_pos head_index d_head, \
+                    batch key_pos head_index d_head \
+                    -> batch head_index query_pos key_pos",
+                q,
+                k,
+            )
         attn_scores = (
             einsum(
                 "batch query_pos head_index d_head, \
@@ -693,7 +700,7 @@ class Attention(nn.Module):
                 :key_ctx_length,
             ],
             attn_scores,
-            self.IGNORE,
+            torch.tensor(-1e5),
         )
 
         # Return the masked attention scores


### PR DESCRIPTION
# Description

This should fix the CI for us. The issue was that a function was reference the global `IGNORE` variable which use to be `torch.tensor(-1e5)`, and has recently been changed to `-tensor.inf` this change then caused the CI to bug out due to massive amounts of data being transformed into nan.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->