### PR TITLE
Improve attention masking and key-value caching.

### DIFF
--- a/tests/unit/test_kv_cache.py
+++ b/tests/unit/test_kv_cache.py
@@ -1,0 +1,265 @@
+import pytest
+import torch as t
+
+from transformer_lens import HookedTransformer
+from transformer_lens.past_key_value_caching import HookedTransformerKeyValueCache
+
+
+# Pythia models seem to have some kind of numerical stability issue.
+# See: https://github.com/neelnanda-io/TransformerLens/issues/385
+@pytest.fixture(scope="session", params=[("gpt2-small", 1e-4), ("pythia-14m", 1e-2)])
+def model_and_atol(request):
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def pretrained(model_and_atol):
+    name, atol = model_and_atol
+    model = HookedTransformer.from_pretrained(name, default_padding_side="left")
+    return model, atol
+
+
+def test_single_new_token(pretrained):
+    model, atol = pretrained
+    pre_prompt = "I went to Staten Island,"
+    pre_prompt_tokens = model.to_tokens(pre_prompt)
+    pre_prompt_tokens_len = pre_prompt_tokens.shape[-1]
+    single_token_post_prompt = " Sharon"
+    single_new_token = model.to_tokens(single_token_post_prompt, prepend_bos=False)
+    full_prompt_tokens = t.cat([pre_prompt_tokens, single_new_token], dim=-1)
+    no_cache_logits = model(full_prompt_tokens)
+    assert full_prompt_tokens.shape[-1] == pre_prompt_tokens_len + 1
+
+    past_kv_cache = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+    model(
+        pre_prompt_tokens,
+        past_kv_cache=past_kv_cache,
+    )
+    with_cache_logits = model(
+        single_new_token,
+        past_kv_cache=past_kv_cache,
+    )
+    assert t.allclose(no_cache_logits[:, -1], with_cache_logits[:, -1], atol=atol)
+    assert t.allclose(no_cache_logits[:, -1:], with_cache_logits, atol=atol)
+
+
+def test_multiple_new_tokens(pretrained):
+    model, atol = pretrained
+    pre_prompt = "I went to Staten Island,"
+    pre_prompt_tokens = model.to_tokens(pre_prompt)
+    pre_prompt_tokens_len = pre_prompt_tokens.shape[-1]
+    post_prompt = " to buy myself a mandolin"
+    new_tokens = model.to_tokens(post_prompt, prepend_bos=False)
+    new_tokens_len = new_tokens.shape[-1]
+    full_prompt_tokens = t.cat([pre_prompt_tokens, new_tokens], dim=-1)
+    assert full_prompt_tokens.shape[-1] == pre_prompt_tokens_len + new_tokens_len
+    no_cache_logits = model(full_prompt_tokens)
+
+    past_kv_cache = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+    model(
+        pre_prompt_tokens,
+        past_kv_cache=past_kv_cache,
+    )
+    with_cache_logits = model(
+        new_tokens,
+        past_kv_cache=past_kv_cache,
+    )
+    assert t.allclose(no_cache_logits[:, -1], with_cache_logits[:, -1], atol=atol)
+    assert t.allclose(
+        no_cache_logits[:, -new_tokens_len:], with_cache_logits, atol=atol
+    )
+
+
+@pytest.mark.parametrize("pre_padding", ["left", "right", None])
+@pytest.mark.parametrize("post_padding", ["left", "right", None])
+def test_multi_token_batch(pretrained, pre_padding, post_padding):
+    model, atol = pretrained
+    padded_batch_pre_prompts = [
+        "It's always locked",
+        "I'd rather be burned in Canada",
+    ]
+    unpadded_batch_pre_prompts = [
+        "It's always locked",
+        "It's always blocked",
+    ]
+    padded_batch_post_prompts = [
+        " by the magistrate",
+        " than to freeze here in the South",
+    ]
+    unpadded_batch_post_prompts = [
+        " by the magistrate",
+        " by the candidate",
+    ]
+
+    first_post_prompt_tokens = model.to_tokens(
+        padded_batch_post_prompts[0], prepend_bos=False
+    )
+    first_full_prompt_tokens = t.cat(
+        [model.to_tokens(padded_batch_pre_prompts[0]), first_post_prompt_tokens], dim=-1
+    )
+    first_post_prompt_len = first_post_prompt_tokens.shape[-1]
+    first_prompt_no_cache_logits = model(first_full_prompt_tokens)
+    first_post_prompt_no_cache_logits = first_prompt_no_cache_logits[
+        0, -first_post_prompt_len:
+    ]
+
+    if pre_padding is None:
+        batch_pre_prompt_tokens = model.to_tokens(unpadded_batch_pre_prompts)
+    else:
+        assert pre_padding == "left" or pre_padding == "right"
+        batch_pre_prompt_tokens = model.to_tokens(
+            padded_batch_pre_prompts, padding_side=pre_padding
+        )
+
+    if post_padding is None:
+        batch_post_prompt_tokens = model.to_tokens(
+            unpadded_batch_post_prompts, prepend_bos=False
+        )
+    else:
+        assert post_padding == "left" or post_padding == "right"
+        batch_post_prompt_tokens = model.to_tokens(
+            padded_batch_post_prompts,
+            prepend_bos=False,
+            padding_side=post_padding,
+        )
+
+    past_kv_cache = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, batch_pre_prompt_tokens.shape[0]
+    )
+    model(
+        batch_pre_prompt_tokens, past_kv_cache=past_kv_cache, padding_side=pre_padding
+    )
+    past_kv_cache.freeze()
+    with_cache_logits = model(
+        batch_post_prompt_tokens,
+        past_kv_cache=past_kv_cache,
+        padding_side=post_padding,
+        prepend_bos=False,
+    )
+    if post_padding == "left" or post_padding is None:
+        first_post_prompt_with_cache_logits = with_cache_logits[
+            0, -first_post_prompt_len:
+        ]
+    else:
+        assert post_padding == "right"
+        first_post_prompt_with_cache_logits = with_cache_logits[
+            0, :first_post_prompt_len
+        ]
+
+    no_cache_probs = t.softmax(first_post_prompt_no_cache_logits, dim=-1)
+    with_cache_probs = t.softmax(first_post_prompt_with_cache_logits, dim=-1)
+    assert t.allclose(no_cache_probs, with_cache_probs, atol=atol)
+
+
+def test_freeze_cache(pretrained):
+    model, atol = pretrained
+    pre_prompt = "I went to Staten Island,"
+    pre_prompt_tokens = model.to_tokens(pre_prompt)
+    post_prompt_1 = " I'm headed to the church to play bingo."
+    new_tokens_1 = model.to_tokens(post_prompt_1, prepend_bos=False)
+    past_kv_cache_1 = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+
+    post_prompt_2 = " shine your light on me, Miss Liberty"
+    new_tokens_2 = model.to_tokens(post_prompt_2, prepend_bos=False)
+    past_kv_cache_2 = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+
+    model(
+        pre_prompt_tokens,
+        past_kv_cache=past_kv_cache_1,
+    )
+    past_kv_cache_1.freeze()
+    with_cache_logits_1 = model(
+        new_tokens_1,
+        past_kv_cache=past_kv_cache_1,
+    )
+
+    model(
+        pre_prompt_tokens,
+        past_kv_cache=past_kv_cache_2,
+    )
+    past_kv_cache_2.freeze()
+    model(
+        new_tokens_2,
+        past_kv_cache=past_kv_cache_2,
+    )
+
+    # Caches frozen at the same point should be identical
+    assert len(past_kv_cache_1.entries) == len(past_kv_cache_2.entries)
+    for entry_1, entry_2 in zip(past_kv_cache_1.entries, past_kv_cache_2.entries):
+        assert entry_1.past_keys.shape == entry_2.past_keys.shape
+        assert entry_1.past_values.shape == entry_2.past_values.shape
+        assert t.allclose(entry_1.past_keys, entry_2.past_keys, atol=1e-3)
+        assert t.allclose(entry_1.past_values, entry_2.past_values, atol=1e-3)
+
+    # Rerunning the same prompt with a different cache that was frozen at the same
+    # point should give the same results
+    with_cache_2_logits_1 = model(
+        new_tokens_1,
+        past_kv_cache=past_kv_cache_2,
+    )
+    assert t.allclose(with_cache_logits_1, with_cache_2_logits_1, atol=atol)
+
+    # Test unfreeze
+    past_kv_cache_2.unfreeze()
+    with_cache_2_logits_1 = model(
+        new_tokens_1,
+        past_kv_cache=past_kv_cache_2,
+    )
+    for entry_1, entry_2 in zip(past_kv_cache_1.entries, past_kv_cache_2.entries):
+        assert entry_1.past_keys.shape[1] < entry_2.past_keys.shape[1]
+        assert entry_1.past_values.shape[1] < entry_2.past_values.shape[1]
+
+    # Rerunning the same prompt with a different cache should give different
+    # results
+    assert t.allclose(with_cache_logits_1, with_cache_2_logits_1, atol=atol)
+    with_cache_2_logits_1 = model(
+        new_tokens_1,
+        past_kv_cache=past_kv_cache_2,
+    )
+    assert not t.allclose(with_cache_logits_1, with_cache_2_logits_1, atol=atol)
+
+
+def test_kv_cache_and_start_at_layer(pretrained):
+    model, atol = pretrained
+    pre_prompt = "I went to Staten Island,"
+    pre_prompt_tokens = model.to_tokens(pre_prompt)
+    pre_prompt_tokens_len = pre_prompt_tokens.shape[-1]
+    single_token_post_prompt = " Sharon"
+    single_new_token = model.to_tokens(single_token_post_prompt, prepend_bos=False)
+    full_prompt_tokens = t.cat([pre_prompt_tokens, single_new_token], dim=-1)
+    no_cache_logits = model(full_prompt_tokens)
+    assert full_prompt_tokens.shape[-1] == pre_prompt_tokens_len + 1
+
+    past_kv_cache = HookedTransformerKeyValueCache.init_cache(
+        model.cfg, model.cfg.device, pre_prompt_tokens.shape[0]
+    )
+    model(
+        pre_prompt_tokens,
+        past_kv_cache=past_kv_cache,
+    )
+    past_kv_cache.freeze()
+    _, toks, shortformer_pos_embed, attn_mask = model.input_to_embed(
+        single_new_token, past_kv_cache=past_kv_cache
+    )
+    _, cache = model.run_with_cache(
+        single_new_token, stop_at_layer=4, past_kv_cache=past_kv_cache
+    )
+    resid_3 = cache["blocks.3.hook_resid_pre"]
+    with_cache_logits = model(
+        resid_3,
+        start_at_layer=3,
+        tokens=toks,
+        shortformer_pos_embed=shortformer_pos_embed,
+        attention_mask=attn_mask,
+        past_kv_cache=past_kv_cache,
+    )
+    assert t.allclose(no_cache_logits[:, -1], with_cache_logits[:, -1], atol=atol)
+    assert t.allclose(no_cache_logits[:, -1:], with_cache_logits, atol=atol)

--- a/tests/unit/test_start_at_layer.py
+++ b/tests/unit/test_start_at_layer.py
@@ -181,19 +181,19 @@ def test_start_at_layer_kwargs():
         rand_embed,
         tokens,
         shortformer_pos_embed,
-        left_attention_mask,
+        attention_mask,
     ) = model.input_to_embed(input)
     assert (
         tokens is not None
         and shortformer_pos_embed is not None
-        and left_attention_mask is not None
+        and attention_mask is not None
     )
 
     start_at_layer_output = model(
         rand_embed,
         tokens=tokens,
         shortformer_pos_embed=shortformer_pos_embed,
-        left_attention_mask=left_attention_mask,
+        attention_mask=attention_mask,
         start_at_layer=0,
         return_type="loss",
     )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -314,23 +314,3 @@ class TestAttentionMask:
             else:
                 # otherwise, there should be no attended but non-pad token
                 assert attended_but_non_pad_mask.sum() == 0
-
-    @pytest.mark.parametrize("prepend_bos", [True, False])
-    def test_get_causal_mask_for_left_padding(self, model, prepend_bos):
-        model.tokenizer.padding_side = "left"
-
-        prompts = self.prompts
-        tokens = model.to_tokens(prompts, prepend_bos=prepend_bos)
-
-        left_attention_mask = utils.get_attention_mask(
-            model.tokenizer, tokens, prepend_bos=prepend_bos
-        )  # [batch pos]
-
-        final_mask = utils.get_causal_mask_for_left_padding(left_attention_mask)
-
-        pad_token_mask = ~left_attention_mask.bool()
-        assert final_mask[pad_token_mask].sum() == 0
-
-        attn = model.blocks[0].attn
-        causal_pad_mask = ~attn.mask[: tokens.shape[1], : tokens.shape[1]]
-        assert final_mask[:, causal_pad_mask].sum() == 0

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -19,12 +19,7 @@ from transformer_lens.FactoredMatrix import FactoredMatrix
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
 from transformer_lens.past_key_value_caching import HookedTransformerKeyValueCacheEntry
-from transformer_lens.utils import (
-    gelu_fast,
-    gelu_new,
-    get_causal_mask_for_left_padding,
-    solu,
-)
+from transformer_lens.utils import gelu_fast, gelu_new, get_offset_position_ids, solu
 
 
 # Embed & Unembed
@@ -88,7 +83,7 @@ class PosEmbed(nn.Module):
         self,
         tokens: Int[torch.Tensor, "batch pos"],
         past_kv_pos_offset: int = 0,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         """
         Forward pass for positional embeddings.
@@ -96,16 +91,15 @@ class PosEmbed(nn.Module):
         Args:
             tokens (Int[torch.Tensor, "batch pos"]): Input tokens.
             past_kv_pos_offset (int, optional): The length of tokens in the past_kv_cache. Defaults to 0.
-            left_attention_mask (Int[torch.Tensor, "batch pos"], optional): The attention mask for left padded tokens.
-                None when right padding is used. Defaults to None.
+            attention_mask (Int[torch.Tensor, "batch pos"], optional): The attention mask for padded tokens.
+                 Defaults to None.
 
         Returns:
             Float[torch.Tensor, "batch pos d_model"]: Absolute position embeddings.
         """
         tokens_length = tokens.size(-1)
 
-        if left_attention_mask is None:
-            # Right padding case
+        if attention_mask is None:
             pos_embed = self.W_pos[
                 past_kv_pos_offset : tokens_length + past_kv_pos_offset, :
             ]  # [pos, d_model]
@@ -114,34 +108,22 @@ class PosEmbed(nn.Module):
             )
 
         else:
-            # Left padding case
-            # Separated from the right padding case for computational efficiency
+            # Separated from the no padding case for computational efficiency
             # (this code is a bit slower than the code above)
 
-            # shift the position ids so that the id at the the first attended token position becomes zero.
-            # The position ids of the prepending pad tokens are shifted to -1.
-            shifted_position_ids = (
-                left_attention_mask.T.cumsum(dim=0) - 1
-            )  # [tokens_length, batch]
+            offset_position_ids = get_offset_position_ids(
+                past_kv_pos_offset, attention_mask
+            )
+            pos_embed = self.W_pos[offset_position_ids]  # [batch, pos, d_model]
 
-            # Set the position ids of all prepending pad tokens to an arbitrary number (zero here)
-            # just to avoid indexing errors.
-            position_ids = shifted_position_ids.masked_fill(shifted_position_ids < 0, 0)
-            offsetted_position_ids = position_ids[
-                past_kv_pos_offset : tokens_length + past_kv_pos_offset, :
-            ]  # [pos, batch]
-            pos_embed = self.W_pos[offsetted_position_ids]  # [pos, batch, d_model]
-
-            # Set the position embeddings to 0 for pad tokens
-            padding_mask = ~left_attention_mask.T.bool()  # [tokens_length, batch]
-            offsetted_padding_mask = padding_mask[
-                past_kv_pos_offset : tokens_length + past_kv_pos_offset, :
+            # Set the position embeddings to 0 for pad tokens (this is an arbitrary choice)
+            padding_mask = ~attention_mask.bool()  # [batch, tokens_length]
+            offset_padding_mask = padding_mask[
+                :, past_kv_pos_offset : tokens_length + past_kv_pos_offset
             ].unsqueeze(
                 -1
-            )  # [pos, batch, 1]
-            batch_pos_embed = torch.where(
-                offsetted_padding_mask, 0, pos_embed
-            ).transpose(0, 1)
+            )  # [batch, pos, 1]
+            batch_pos_embed = torch.where(offset_padding_mask, 0, pos_embed)
 
         return batch_pos_embed.clone()
 
@@ -538,13 +520,13 @@ class Attention(nn.Module):
         ],
         past_kv_cache_entry: Optional[HookedTransformerKeyValueCacheEntry] = None,
         additive_attention_mask: Optional[Float[torch.Tensor, "batch 1 1 pos"]] = None,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         """
         shortformer_pos_embed is only used if self.cfg.positional_embedding_type == "shortformer", else defaults to None and is irrelevant. See HookedTransformerConfig for more details
         past_kv_cache_entry is an optional entry of past keys and values for this layer, only relevant if generating text. Defaults to None
         additive_attention_mask is an optional mask to add to the attention weights. Defaults to None.
-        left_attention_mask is the attention mask for left padded tokens. None when right padding is used. Defaults to None.
+        attention_mask is the attention mask for padded tokens. Defaults to None.
         """
 
         if self.cfg.use_split_qkv_input or self.cfg.use_attn_in:
@@ -589,7 +571,12 @@ class Attention(nn.Module):
             kv_cache_pos_offset = 0
 
         if self.cfg.positional_embedding_type == "rotary":
-            q, k = self.rotary_rotate_qk(q, k, kv_cache_pos_offset)
+            q = self.hook_rot_q(
+                self.apply_rotary(q, kv_cache_pos_offset, attention_mask)
+            )
+            k = self.hook_rot_k(
+                self.apply_rotary(k, 0, attention_mask)
+            )  # keys are cached so no offset
 
         if self.cfg.dtype not in [torch.float32, torch.float64]:
             # If using 16 bits, increase the precision to avoid numerical instabilities
@@ -609,7 +596,7 @@ class Attention(nn.Module):
         if self.cfg.attention_dir == "causal":
             # If causal attention, we mask it to only attend backwards. If bidirectional, we don't mask.
             attn_scores = self.apply_causal_mask(
-                attn_scores, kv_cache_pos_offset, left_attention_mask
+                attn_scores, kv_cache_pos_offset, attention_mask
             )  # [batch, head_index, query_pos, key_pos]
         if additive_attention_mask is not None:
             attn_scores += additive_attention_mask
@@ -667,9 +654,9 @@ class Attention(nn.Module):
             torch.Tensor, "batch head_index pos pos_plus_past_kv_pos_offset"
         ],
         past_kv_pos_offset: int = 0,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ):
-        # The query context length is the number of positions we take queries from - if not using a past_kv_cache this is just the context length (for the current prompt), but if we're caching it's just a single token.
+        # The query context length is the number of positions we take queries from - if not using a past_kv_cache this is just the context length (for the current prompt), but if we're caching it can be different.
         query_ctx_length = attn_scores.size(-2)
         # The key context length is the number of positions in the past - this includes all positions in the cache
         # If not caching, query_ctx_length == key_ctx_length
@@ -679,45 +666,16 @@ class Attention(nn.Module):
             query_ctx_length + past_kv_pos_offset == key_ctx_length
         ), f"query_ctx_length {query_ctx_length} + past_kv_pos_offset {past_kv_pos_offset} != key_ctx_length {key_ctx_length} - you likely have a bug."
 
-        if left_attention_mask is None:
-            # Right padding case
-            # Apply only a causal mask to the attention scores
-            final_mask = self.mask[None, None]  # [1, 1, pos, pos]
-        else:
-            # Left padding case
-            # Apply a causal mask to the attention scores considering the left padding
-            final_mask = get_causal_mask_for_left_padding(left_attention_mask)
-            final_mask = final_mask.unsqueeze(1).to(
-                attn_scores.device
-            )  # [batch, 1, pos, pos]
+        # Index back to front to ensure local attention works
+        final_mask = self.mask[
+            None, None, -query_ctx_length:, -key_ctx_length:
+        ]  # [1, 1, pos, pos]
+        if attention_mask is not None:
+            # Apply a causal mask to the attention scores considering the padding
+            einsum_str = "batch head pos offset_pos, batch offset_pos -> batch head pos offset_pos"
+            final_mask = einops.einsum(final_mask, attention_mask, einsum_str).bool()
 
-        masked_attn_scores = torch.where(
-            final_mask[
-                :,
-                :,
-                past_kv_pos_offset : past_kv_pos_offset + query_ctx_length,
-                :key_ctx_length,
-            ],
-            attn_scores,
-            self.IGNORE,
-        )
-
-        # Return the masked attention scores
-        return masked_attn_scores
-
-    def rotary_rotate_qk(
-        self,
-        q: Float[torch.Tensor, "batch q_pos head_index d_head"],
-        k: Float[torch.Tensor, "batch k_pos head_index d_head"],
-        past_kv_pos_offset,
-    ) -> Tuple[
-        Float[torch.Tensor, "batch q_pos head_index d_head"],
-        Float[torch.Tensor, "batch k_pos head_index d_head"],
-    ]:
-        # We first apply standard q and k calculation
-        q = self.hook_rot_q(self.apply_rotary(q, past_kv_pos_offset))
-        k = self.hook_rot_k(self.apply_rotary(k))
-        return q, k
+        return torch.where(final_mask, attn_scores, self.IGNORE)
 
     def calculate_sin_cos_rotary(
         self,
@@ -773,18 +731,30 @@ class Attention(nn.Module):
         self,
         x: Float[torch.Tensor, "batch pos head_index d_head"],
         past_kv_pos_offset=0,
+        attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ) -> Float[torch.Tensor, "batch pos head_index d_head"]:
         # Only apply rotary to first rotary_dim dimensions (eg, if rotary_dim=64 and d_head=256, only apply to first 1/4 of dimensions)
         x_pos = x.size(1)
         x_rot = x[..., : self.cfg.rotary_dim]
         x_pass = x[..., self.cfg.rotary_dim :]
         x_flip = self.rotate_every_two(x_rot)
-        x_rotated = (
-            x_rot
-            * self.rotary_cos[past_kv_pos_offset : past_kv_pos_offset + x_pos, None, :]
-            + x_flip
-            * self.rotary_sin[past_kv_pos_offset : past_kv_pos_offset + x_pos, None, :]
-        )
+
+        if attention_mask is None:
+            rotary_cos = self.rotary_cos[
+                None, past_kv_pos_offset : past_kv_pos_offset + x_pos, None, :
+            ]
+            rotary_sin = self.rotary_sin[
+                None, past_kv_pos_offset : past_kv_pos_offset + x_pos, None, :
+            ]
+            x_rotated = x_rot * rotary_cos + x_flip * rotary_sin
+        else:
+            offset_position_ids = get_offset_position_ids(
+                past_kv_pos_offset, attention_mask
+            )
+            mask_rotary_cos = self.rotary_cos[offset_position_ids, None, :]
+            mask_rotary_sin = self.rotary_sin[offset_position_ids, None, :]
+            x_rotated = x_rot * mask_rotary_cos + x_flip * mask_rotary_sin
+
         return torch.cat([x_rotated, x_pass], dim=-1)
 
 
@@ -1008,7 +978,7 @@ class TransformerBlock(nn.Module):
             Float[torch.Tensor, "batch pos d_model"]
         ] = None,
         past_kv_cache_entry: Optional[HookedTransformerKeyValueCacheEntry] = None,
-        left_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+        attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         """A single Transformer block.
 
@@ -1016,7 +986,7 @@ class TransformerBlock(nn.Module):
             resid_pre (torch.Tensor): The residual stream - shape [batch, pos, d_model]
             cache (HookedTransformerKeyValueCache): A cache of previous keys and values, used only when generating text. Defaults to None.
             shortformer_pos_embed (torch.Tensor, optional): Only used for positional_embeddings_type == "shortformer". The positional embeddings. See HookedTransformerConfig for details. Defaults to None.
-            left_attention_mask (torch.Tensor, optional): The attention mask for left padded tokens. None when right padding is used. Defaults to None.
+            attention_mask (torch.Tensor, optional): The attention mask for padded tokens. Defaults to None.
 
         Returns:
             _type_: _description_
@@ -1069,7 +1039,7 @@ class TransformerBlock(nn.Module):
                 + (0.0 if shortformer_pos_embed is None else shortformer_pos_embed),
                 value_input=self.ln1(value_input),
                 past_kv_cache_entry=past_kv_cache_entry,
-                left_attention_mask=left_attention_mask,
+                attention_mask=attention_mask,
             )
         )  # [batch, pos, d_model]
         if not self.cfg.attn_only and not self.cfg.parallel_attn_mlp:

--- a/transformer_lens/past_key_value_caching.py
+++ b/transformer_lens/past_key_value_caching.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import List, Union
 
 import torch
-from jaxtyping import Float
+from jaxtyping import Float, Int
 
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
 from transformer_lens.utilities.devices import get_device_for_block_index
@@ -18,6 +18,7 @@ from transformer_lens.utilities.devices import get_device_for_block_index
 class HookedTransformerKeyValueCacheEntry:
     past_keys: Float[torch.Tensor, "batch pos_so_far n_heads d_head"]
     past_values: Float[torch.Tensor, "batch pos_so_far n_heads d_head"]
+    frozen: bool = False
 
     @classmethod
     def init_cache_entry(
@@ -46,8 +47,9 @@ class HookedTransformerKeyValueCacheEntry:
         updated_values: Float[
             torch.Tensor, "batch pos_so_far_plus_new_tokens n_heads d_head"
         ] = torch.cat([self.past_values, new_values], dim=1)
-        self.past_keys = updated_keys
-        self.past_values = updated_values
+        if not self.frozen:
+            self.past_keys = updated_keys
+            self.past_values = updated_values
         return updated_keys, updated_values
 
 
@@ -58,11 +60,12 @@ class HookedTransformerKeyValueCache:
 
     This cache is a list of HookedTransformerKeyValueCacheEntry objects, one for each layer in the Transformer. Each object stores a [batch, pos_so_far, n_heads, d_head] tensor for both keys and values, and each entry has an append method to add a single new key and value.
 
-    Generation is assumed to be done by initializing with some prompt and then continuing iteratively one token at a time. So append only works for adding a single token's worth of keys and values, and but the cache can be initialized with many.
-
+    The cache can be frozen so that it is not updated during the forward pass. This is useful when we want to run many inputs with the same prefix.
     """
 
     entries: List[HookedTransformerKeyValueCacheEntry]
+    previous_attention_mask: Int[torch.Tensor, "batch pos_so_far"]
+    frozen: bool = False
 
     @classmethod
     def init_cache(
@@ -79,8 +82,36 @@ class HookedTransformerKeyValueCache:
                     batch_size,
                 )
                 for i in range(cfg.n_layers)
-            ]
+            ],
+            previous_attention_mask=torch.empty(
+                # This may actually be an int64, but type promotion will handle it:
+                # See: https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc
+                # See: https://github.com/pytorch/pytorch/issues/35014
+                (batch_size, 0),
+                device=device,
+                dtype=torch.int,
+            ),
         )
+
+    def freeze(self):
+        self.frozen = True
+        for entry in self.entries:
+            entry.frozen = True
+
+    def unfreeze(self):
+        self.frozen = False
+        for entry in self.entries:
+            entry.frozen = False
+
+    def append_attention_mask(
+        self, attention_mask: Int[torch.Tensor, "batch new_tokens"]
+    ):
+        updated_attention_mask = torch.cat(
+            [self.previous_attention_mask, attention_mask], dim=-1
+        )
+        if not self.frozen:
+            self.previous_attention_mask = updated_attention_mask
+        return updated_attention_mask
 
     def __getitem__(self, idx):
         return self.entries[idx]


### PR DESCRIPTION
# Description

- Support passing in multiple tokens when using `past_kv_cache`.
- Change `left_attention_mask` to `attention_mask`. Update `apply_causal_mask` and `apply_rotary` to support arbitrary masking (and do it faster). This means that caching 'just works' regardless of padding. So you can, for example, cache keys and values for a batch of tokens and then run a left padded batch of tokens, and the padding tokens in the middle of the sequence will be ignored.
- Add tests for `past_kv_cache`.
- Add `test_pos_embed_with_cache` in `test_left_padding`.
- Add documentation for `past_kv_cache`.
- Fix type hints for some components that assume `attention_mask` has same number of tokens as input. This was previously unnoticed because there were no tests that covered `past_kv_cache`.
- Support freezing key-value caches.
- Integrate `past_attention_mask` into HookedTransformerKeyValueCache so that it doesn't need to managed manually.
- Fix bug caused by previous PR #382. start_at_layer would cause enumerate to produce incorrect block indices in `HookedTransformer.forward()`.


## Motivation for arbitrary padding

1. This implementation is simpler and faster than the previous left-padding implementation.
2. It allows us to use caching while running batches with arbitrary padding. For example, I can cache a batch of prompts and then run another batch of left-padded prompts which makes it simpler to index the final token in each prompt. 

## Motivation for allowing multiple tokens to run with key value cache

In ACDC we run the same prompt many times. Patching only affects token positions after the point where the clean and corrupt prompts differ. We want to run the first part of the prompt that is identical between clean and corrupt, freeze the cache, then pass in only the tokens after the point of divergence for our patched runs.

## Breaking changes

Removes `past_left_attention_mask` from `HookedTransformer.forward()` because the `left_attention_mask` (now just `attention_mask`) of previous inputs is stored automatically by `HookedTransformerKeyValueCache`. I think this won't break many people's code as this argument was only added 4 weeks ago in #344. And the fix should be quite trivial as it only requires deleting this input.

Overall I think the benefits are worth the cost as this makes caching easier to do and generally reduces complexity. I can't think of any case where someone would want to pass in a `past_attention_mask` that doesn't match `past_kv_cache`.

Renames `left_attention_mask` to `attention_mask`. This was introduced 2 weeks ago in #382, so is probably also fine.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility