### PR TITLE
Added explicit dtype option

### DIFF
--- a/transformer_lens/HookedEncoder.py
+++ b/transformer_lens/HookedEncoder.py
@@ -201,6 +201,7 @@ class HookedEncoder(HookedRootModule):
         device: Optional[str] = None,
         tokenizer=None,
         move_to_device=True,
+        dtype=torch.float32,
         **from_pretrained_kwargs,
     ) -> HookedEncoder:
         """Loads in the pretrained weights from huggingface. Currently supports loading weight from HuggingFace BertForMaskedLM. Unlike HookedTransformer, this does not yet do any preprocessing on the model."""
@@ -220,6 +221,9 @@ class HookedEncoder(HookedRootModule):
             or from_pretrained_kwargs.get("load_in_4bit", False)
         ), "Quantization not supported"
 
+        if "torch_dtype" in from_pretrained_kwargs:
+            dtype = from_pretrained_kwargs["torch_dtype"]
+
         official_model_name = loading.get_official_model_name(model_name)
 
         cfg = loading.get_pretrained_model_config(
@@ -229,11 +233,12 @@ class HookedEncoder(HookedRootModule):
             fold_ln=False,
             device=device,
             n_devices=1,
+            dtype=dtype,
             **from_pretrained_kwargs,
         )
 
         state_dict = loading.get_pretrained_state_dict(
-            official_model_name, cfg, hf_model, **from_pretrained_kwargs
+            official_model_name, cfg, hf_model, dtype=dtype, **from_pretrained_kwargs
         )
 
         model = cls(cfg, tokenizer, move_to_device=False)

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -775,6 +775,7 @@ def get_pretrained_model_config(
     device: Optional[str] = None,
     n_devices: int = 1,
     default_prepend_bos: bool = True,
+    dtype: torch.dtype = torch.float32,
     **kwargs,
 ):
     """Returns the pretrained model config as an HookedTransformerConfig object.
@@ -806,6 +807,7 @@ def get_pretrained_model_config(
             so this empirically seems to give better results. To change the default behavior to False, pass in
             default_prepend_bos=False. Note that you can also locally override the default behavior by passing
             in prepend_bos=True/False when you call a method that processes the input string.
+        dtype (torch.dtype, optional): The dtype to load the TransformerLens model in.
         kwargs: Other optional arguments passed to HuggingFace's from_pretrained.
             Also given to other HuggingFace functions when compatible.
 
@@ -838,10 +840,7 @@ def get_pretrained_model_config(
     if device is not None:
         cfg_dict["device"] = device
 
-    if kwargs.get("torch_dtype", None) is not None:
-        cfg_dict["dtype"] = kwargs["torch_dtype"]
-    elif "dtype" in cfg_dict:
-        kwargs["torch_dtype"] = cfg_dict["dtype"]
+    cfg_dict["dtype"] = dtype
 
     if fold_ln:
         if cfg_dict["normalization_type"] in ["LN", "LNPre"]:
@@ -943,6 +942,7 @@ def get_pretrained_state_dict(
     official_model_name: str,
     cfg: HookedTransformerConfig,
     hf_model=None,
+    dtype: torch.dtype = torch.float32,
     **kwargs,
 ) -> Dict[str, torch.Tensor]:
     """
@@ -952,6 +952,7 @@ def get_pretrained_state_dict(
 
     hf_model: Optionally, a HuggingFace model object. If provided, we will use
         these weights rather than reloading the model.
+    dtype: The dtype to load the HuggingFace model in.
     kwargs: Other optional arguments passed to HuggingFace's from_pretrained.
         Also given to other HuggingFace functions when compatible.
     """
@@ -975,9 +976,9 @@ def get_pretrained_state_dict(
         state_dict = utils.download_file_from_hf(
             official_model_name, file_name, **kwargs
         )
-        dtype = kwargs.get("torch_dtype", None)
-        if dtype is not None:
-            state_dict = {k: v.to(dtype) for k, v in state_dict.items()}
+        
+        # Convert to dtype
+        state_dict = {k: v.to(dtype) for k, v in state_dict.items()}
 
         if cfg.original_architecture == "neel-solu-old":
             state_dict = convert_neel_solu_old_weights(state_dict, cfg)
@@ -990,12 +991,14 @@ def get_pretrained_state_dict(
                 hf_model = AutoModelForCausalLM.from_pretrained(
                     official_model_name,
                     revision=f"checkpoint-{cfg.checkpoint_value}",
+                    torch_dtype=dtype,
                     **kwargs,
                 )
             elif official_model_name.startswith("EleutherAI/pythia"):
                 hf_model = AutoModelForCausalLM.from_pretrained(
                     official_model_name,
                     revision=f"step{cfg.checkpoint_value}",
+                    torch_dtype=dtype,
                     **kwargs,
                 )
             else:
@@ -1007,11 +1010,15 @@ def get_pretrained_state_dict(
                 raise NotImplementedError("Must pass in hf_model for LLaMA models")
             elif "bert" in official_model_name:
                 hf_model = BertForPreTraining.from_pretrained(
-                    official_model_name, **kwargs
+                    official_model_name,
+                    torch_dtype=dtype,
+                    **kwargs
                 )
             else:
                 hf_model = AutoModelForCausalLM.from_pretrained(
-                    official_model_name, **kwargs
+                    official_model_name,
+                    torch_dtype=dtype,
+                    **kwargs
                 )
 
             # Load model weights, and fold in layer norm weights

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -956,6 +956,9 @@ def get_pretrained_state_dict(
     kwargs: Other optional arguments passed to HuggingFace's from_pretrained.
         Also given to other HuggingFace functions when compatible.
     """
+    if "torch_dtype" in kwargs:
+        dtype = kwargs["torch_dtype"]
+        del kwargs["torch_dtype"]
     official_model_name = get_official_model_name(official_model_name)
     if (
         official_model_name.startswith("NeelNanda")

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -976,7 +976,7 @@ def get_pretrained_state_dict(
         state_dict = utils.download_file_from_hf(
             official_model_name, file_name, **kwargs
         )
-        
+
         # Convert to dtype
         state_dict = {k: v.to(dtype) for k, v in state_dict.items()}
 
@@ -1010,15 +1010,11 @@ def get_pretrained_state_dict(
                 raise NotImplementedError("Must pass in hf_model for LLaMA models")
             elif "bert" in official_model_name:
                 hf_model = BertForPreTraining.from_pretrained(
-                    official_model_name,
-                    torch_dtype=dtype,
-                    **kwargs
+                    official_model_name, torch_dtype=dtype, **kwargs
                 )
             else:
                 hf_model = AutoModelForCausalLM.from_pretrained(
-                    official_model_name,
-                    torch_dtype=dtype,
-                    **kwargs
+                    official_model_name, torch_dtype=dtype, **kwargs
                 )
 
             # Load model weights, and fold in layer norm weights


### PR DESCRIPTION
# Description

A cosmetic change to add a dtype option on from_pretrained. Previously you could set torch_dtype and it would work, but this was not documented (and I didn't realise it until implementing a PR for mixed precision lol)