### PR TITLE
Remove .venv from formatting checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ addopts = "--jaxtyping-packages=transformer_lens,beartype.beartype"
 
 [tool.isort]
 profile = "black"
-extend_skip = ["__init__.py"]
+extend_skip = ["__init__.py", ".venv/"]
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -79,9 +79,10 @@ max-locals = 30
 disable = "redefined-builtin" # Disable redefined builtin functions
 
 [tool.black]
-# Exclude snapshot tests
+# Exclude snapshot tests & .venv
 exclude = '''
 (
 /snapshots/
+| .venv/
 )
 '''


### PR DESCRIPTION
This is slowing down formatting checks where Poetry is installing into a local .venv folder (as it also formats all Python dependencies).