### PR TITLE
Add auto-organise imports on save in VsCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },


### PR DESCRIPTION
Small tweak to reduce reliance on `make format`.