### PR TITLE
Update docs to show prepend_bos and padding_side are optional

### DIFF
--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -625,6 +625,12 @@ def test_prompt(
     Works for multi-token answers and multi-token prompts.
 
     Will always print the ranks of the answer tokens, and if print_details will print the logit and prob for the answer tokens and the top k tokens returned for each answer position.
+
+    Args:
+        prepend_bos (bool, optional): Overrides self.cfg.default_prepend_bos. Whether to prepend
+            the BOS token to the input (applicable when input is a string). Defaults to None,
+            implying usage of self.cfg.default_prepend_bos (default is True unless specified
+            otherwise). Pass True or False to override the default.
     """
     if prepend_space_to_answer and not answer.startswith(" "):
         answer = " " + answer


### PR DESCRIPTION
# Description

 - Improve documentation for prepend_bos and padding_side in several functions in HookedTransformer and utils. It is currently unclear that they are just intended to be used as overrides of the default values set in the initial config.
 - Improve the syntax of some type hints.

## Type of change

- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility