### PR TITLE
Add docs hot reloading instructions for contributors

### DIFF
--- a/docs/source/content/contributing.md
+++ b/docs/source/content/contributing.md
@@ -48,6 +48,9 @@ in the docstring, and this will then automatically generate the API docs when me
 They will also be automatically checked with [pytest](https://docs.pytest.org/) (via
 [doctest](https://docs.python.org/3/library/doctest.html)).
 
+If you want to view your documentation changes, run `pytest run docs-hot-reload`. This will give you
+hot-reloading docs (they change in real time as you edit docstrings).
+
 ### Docstring Style Guide
 
 We follow the Google Python Docstring Style for writing docstrings, with some added features from

--- a/makefile
+++ b/makefile
@@ -25,3 +25,9 @@ test:
 	make acceptance-test
 	make docstring-test
 	make notebook-test
+
+docs-hot-reload:
+	poetry run docs-hot-reload
+
+build-docs:
+	poetry run build-docs


### PR DESCRIPTION
Note these are also added to the makefile as this is currently the approach people use to run the tests. In the future we should probably remove this as it's better to stick to one language in the repo (and a .py script file can also do all of this).