### PR TITLE
Fixes #371: LLAMA load on CUDA. Expected all tensors to be on the sam…

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1382,20 +1382,22 @@ def convert_llama_weights(llama, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.attn.W_V"] = W_V
 
         state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(
-            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype, device=cfg.device
         )
         state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(
-            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype, device=cfg.device
         )
         state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(
-            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype, device=cfg.device
         )
 
         W_O = llama.model.layers[l].self_attn.o_proj.weight
         W_O = einops.rearrange(W_O, "m (n h)->n h m", n=cfg.n_heads)
         state_dict[f"blocks.{l}.attn.W_O"] = W_O
 
-        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(
+            cfg.d_model, dtype=cfg.dtype, device=cfg.device
+        )
 
         state_dict[f"blocks.{l}.ln2.w"] = llama.model.layers[
             l
@@ -1405,17 +1407,23 @@ def convert_llama_weights(llama, cfg: HookedTransformerConfig):
         state_dict[f"blocks.{l}.mlp.W_gate"] = llama.model.layers[
             l
         ].mlp.gate_proj.weight.T
-        state_dict[f"blocks.{l}.mlp.b_in"] = torch.zeros(cfg.d_mlp, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.mlp.b_in"] = torch.zeros(
+            cfg.d_mlp, dtype=cfg.dtype, device=cfg.device
+        )
 
         state_dict[f"blocks.{l}.mlp.W_out"] = llama.model.layers[
             l
         ].mlp.down_proj.weight.T
-        state_dict[f"blocks.{l}.mlp.b_out"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.mlp.b_out"] = torch.zeros(
+            cfg.d_model, dtype=cfg.dtype, device=cfg.device
+        )
 
     state_dict["ln_final.w"] = llama.model.norm.weight
 
     state_dict["unembed.W_U"] = llama.lm_head.weight.T
-    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
+    state_dict["unembed.b_U"] = torch.zeros(
+        cfg.d_vocab, dtype=cfg.dtype, device=cfg.device
+    )
 
     return state_dict
 


### PR DESCRIPTION
Fixes error: "Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!"


# Description

When loading LLAMA 2 7B:
```
device = torch.device("cuda" if torch.cuda.is_available() else "cpu")  # CUDA
model_type = torch.bfloat16

hf_model = LlamaForCausalLM.from_pretrained(
    "meta-llama/Llama-2-7b-chat-hf",
    torch_dtype=model_type,
    device_map=device,
)
tokenizer = LlamaTokenizer.from_pretrained(
    "meta-llama/Llama-2-7b-chat-hf",
    device_map=device,
)

model = HookedTransformer.from_pretrained(
    "meta-llama/Llama-2-7b-chat-hf",
    hf_model=hf_model,
    fold_ln=False,
    center_writing_weights=False,
    center_unembed=False,
    tokenizer=tokenizer,
    device=device,
    dtype=model_type,
    use_attn_result=True,
    use_split_qkv_input=True,
)
```
It fails with 
```
RuntimeError                              Traceback (most recent call last)
[/workspace/dlkworks/llama.py](https://vscode-remote+ssh-002dremote-002b50-002e217-002e254-002e168.vscode-resource.vscode-cdn.net/workspace/dlkworks/llama.py) in line 2
      [782](file:///workspace/dlkworks/llama.py?line=781) # %%
----> [783](file:///workspace/dlkworks/llama.py?line=782) model = HookedTransformer.from_pretrained(
      [784](file:///workspace/dlkworks/llama.py?line=783)     "meta-llama/Llama-2-7b-chat-hf",
      [785](file:///workspace/dlkworks/llama.py?line=784)     hf_model=hf_model,
      [786](file:///workspace/dlkworks/llama.py?line=785)     device=device,
      [787](file:///workspace/dlkworks/llama.py?line=786)     fold_ln=False,
      [788](file:///workspace/dlkworks/llama.py?line=787)     center_writing_weights=False,
      [789](file:///workspace/dlkworks/llama.py?line=788)     center_unembed=False,
      [790](file:///workspace/dlkworks/llama.py?line=789)     tokenizer=tokenizer,
     [791](file:///workspace/dlkworks/llama.py?line=790)     dtype=model_type,
     [792](file:///workspace/dlkworks/llama.py?line=791)     use_attn_result=True,
     [793](file:///workspace/dlkworks/llama.py?line=792)     use_split_qkv_input=True,
     [794](file:///workspace/dlkworks/llama.py?line=793) )
     [795](file:///workspace/dlkworks/llama.py?line=794) #model = model.to(device)
     [796](file:///workspace/dlkworks/llama.py?line=795) model.eval()

File [/workspace/TransformerLens/transformer_lens/HookedTransformer.py:1294](https://vscode-remote+ssh-002dremote-002b50-002e217-002e254-002e168.vscode-resource.vscode-cdn.net/workspace/TransformerLens/transformer_lens/HookedTransformer.py:1294), in HookedTransformer.from_pretrained(cls, model_name, fold_ln, center_writing_weights, center_unembed, refactor_factored_attn_matrices, checkpoint_index, checkpoint_value, hf_model, device, n_devices, tokenizer, move_to_device, fold_value_biases, default_prepend_bos, default_padding_side, dtype, **from_pretrained_kwargs)
   [1286](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1285) # Create the HookedTransformer object
   [1287](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1286) model = cls(
   [1288](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1287)     cfg,
   [1289](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1288)     tokenizer,
   [1290](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1289)     move_to_device=False,
   [1291](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1290)     default_padding_side=default_padding_side,
   [1292](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1291) )
-> [1294](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1293) model.load_and_process_state_dict(
   [1295](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1294)     state_dict,
   [1296](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1295)     fold_ln=fold_ln,
   [1297](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1296)     center_writing_weights=center_writing_weights,
   [1298](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1297)     center_unembed=center_unembed,
   [1299](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1298)     fold_value_biases=fold_value_biases,
   [1300](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1299)     refactor_factored_attn_matrices=refactor_factored_attn_matrices,
   [1301](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1300) )
   [1303](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1302) if move_to_device:
   [1304](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1303)     model.move_model_modules_to_device()

File [/workspace/TransformerLens/transformer_lens/HookedTransformer.py:1441](https://vscode-remote+ssh-002dremote-002b50-002e217-002e254-002e168.vscode-resource.vscode-cdn.net/workspace/TransformerLens/transformer_lens/HookedTransformer.py:1441), in HookedTransformer.load_and_process_state_dict(self, state_dict, fold_ln, center_writing_weights, center_unembed, fold_value_biases, refactor_factored_attn_matrices)
   [1439](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1438)     state_dict = self.center_unembed(state_dict)
   [1440](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1439) if fold_value_biases:
-> [1441](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1440)     state_dict = self.fold_value_biases(state_dict)
   [1442](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1441) if refactor_factored_attn_matrices:
   [1443](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1442)     state_dict = self.refactor_factored_attn_matrices(state_dict)

File [/workspace/TransformerLens/transformer_lens/HookedTransformer.py:1656](https://vscode-remote+ssh-002dremote-002b50-002e217-002e254-002e168.vscode-resource.vscode-cdn.net/workspace/TransformerLens/transformer_lens/HookedTransformer.py:1656), in HookedTransformer.fold_value_biases(self, state_dict)
   [1653](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1652) # [d_model]
   [1654](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1653) b_O_original = state_dict[f"blocks.{layer}.attn.b_O"]
-> [1656](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1655) folded_b_O = b_O_original + (b_V[:, :, None] * W_O).sum([0, 1])
   [1658](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1657) state_dict[f"blocks.{layer}.attn.b_O"] = folded_b_O
   [1659](file:///workspace/TransformerLens/transformer_lens/HookedTransformer.py?line=1658) state_dict[f"blocks.{layer}.attn.b_V"] = torch.zeros_like(b_V)

RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Fixes https://github.com/neelnanda-io/TransformerLens/issues/371

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility
