### PR TITLE
Add support for CodeLlama-7b

### DIFF
--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -197,6 +197,7 @@ class HookedTransformerConfig:
     dtype: torch.dtype = torch.float32
     tokenizer_prepends_bos: Optional[bool] = None
     post_embedding_ln: bool = False
+    rotary_base: int = 10000
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -479,7 +479,10 @@ class Attention(nn.Module):
             self.hook_rot_k = HookPoint()
             self.hook_rot_q = HookPoint()
             sin, cos = self.calculate_sin_cos_rotary(
-                self.cfg.rotary_dim, self.cfg.n_ctx, base=self.cfg.rotary_base, dtype=self.cfg.dtype
+                self.cfg.rotary_dim,
+                self.cfg.n_ctx,
+                base=self.cfg.rotary_base,
+                dtype=self.cfg.dtype,
             )
             self.register_buffer("rotary_sin", sin)
             self.register_buffer("rotary_cos", cos)

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -479,7 +479,7 @@ class Attention(nn.Module):
             self.hook_rot_k = HookPoint()
             self.hook_rot_q = HookPoint()
             sin, cos = self.calculate_sin_cos_rotary(
-                self.cfg.rotary_dim, self.cfg.n_ctx, dtype=self.cfg.dtype
+                self.cfg.rotary_dim, self.cfg.n_ctx, base=self.cfg.rotary_base, dtype=self.cfg.dtype
             )
             self.register_buffer("rotary_sin", sin)
             self.register_buffer("rotary_cos", cos)

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -464,8 +464,14 @@ MODEL_ALIASES = {
     "llama-30b-hf": ["llama-30b"],
     "llama-65b-hf": ["llama-65b"],
     "CodeLlama-7b-hf": ["CodeLlamallama-2-7b", "codellama/CodeLlama-7b-hf"],
-    "CodeLlama-7b-Python-hf": ["CodeLlama-7b-python", "codellama/CodeLlama-7b-Python-hf"],
-    "CodeLlama-7b-Instruct-hf": ["CodeLlama-7b-instruct", "codellama/CodeLlama-7b-Instruct-hf"],
+    "CodeLlama-7b-Python-hf": [
+        "CodeLlama-7b-python",
+        "codellama/CodeLlama-7b-Python-hf",
+    ],
+    "CodeLlama-7b-Instruct-hf": [
+        "CodeLlama-7b-instruct",
+        "codellama/CodeLlama-7b-Instruct-hf",
+    ],
     "Llama-2-7b-hf": ["Llama-2-7b", "meta-llama/Llama-2-7b-hf"],
     "Llama-2-7b-chat-hf": ["Llama-2-7b-chat", "meta-llama/Llama-2-7b-chat-hf"],
     "Llama-2-13b-hf": ["Llama-2-13b", "meta-llama/Llama-2-13b-hf"],
@@ -578,25 +584,26 @@ def convert_hf_model_config(model_name: str, **kwargs):
         }
     elif official_model_name.startswith(
         "CodeLlama-7b"
-    ): # same architecture CodeLlama and Llama-2
+    ):  # same architecture CodeLlama and Llama-2
         cfg_dict = {
-                    "d_model": 4096,
-                    "d_head": 4096 // 32,
-                    "n_heads": 32,
-                    "d_mlp": 11008,
-                    "n_layers": 32,
-                    "n_ctx": 4096,
-                    "eps": 1e-5,
-                    "d_vocab": 32016,
-                    "act_fn": "silu",
-                    "normalization_type": "RMS",
-                    "positional_embedding_type": "rotary",
-                    "rotary_dim": 4096 // 32,
-                    "final_rms": True,
-                    "gated_mlp": True,
-                    "rotary_base":  1000000
-                }
+            "d_model": 4096,
+            "d_head": 4096 // 32,
+            "n_heads": 32,
+            "d_mlp": 11008,
+            "n_layers": 32,
+            "n_ctx": 4096,
+            "eps": 1e-5,
+            "d_vocab": 32016,
+            "act_fn": "silu",
+            "normalization_type": "RMS",
+            "positional_embedding_type": "rotary",
+            "rotary_dim": 4096 // 32,
+            "final_rms": True,
+            "gated_mlp": True,
+            "rotary_base": 1000000,
+        }
         if "python" in official_model_name.lower():
+            # The vocab size of python version of CodeLlama-7b is 32000
             cfg_dict["d_vocab"] = 32000
     elif official_model_name.startswith(
         ("llama-13b", "Llama-2-13b")

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -111,6 +111,9 @@ OFFICIAL_MODEL_NAMES = [
     "llama-13b-hf",
     "llama-30b-hf",
     "llama-65b-hf",
+    "CodeLlama-7b-hf",
+    "CodeLlama-7b-Python-hf",
+    "CodeLlama-7b-Instruct-hf",
     "Llama-2-7b-hf",
     "Llama-2-7b-chat-hf",
     "Llama-2-13b-hf",
@@ -460,6 +463,9 @@ MODEL_ALIASES = {
     "llama-13b-hf": ["llama-13b"],
     "llama-30b-hf": ["llama-30b"],
     "llama-65b-hf": ["llama-65b"],
+    "CodeLlama-7b-hf": ["CodeLlamallama-2-7b", "codellama/CodeLlama-7b-hf"],
+    "CodeLlama-7b-Python-hf": ["CodeLlama-7b-python", "codellama/CodeLlama-7b-Python-hf"],
+    "CodeLlama-7b-Instruct-hf": ["CodeLlama-7b-instruct", "codellama/CodeLlama-7b-Instruct-hf"],
     "Llama-2-7b-hf": ["Llama-2-7b", "meta-llama/Llama-2-7b-hf"],
     "Llama-2-7b-chat-hf": ["Llama-2-7b-chat", "meta-llama/Llama-2-7b-chat-hf"],
     "Llama-2-13b-hf": ["Llama-2-13b", "meta-llama/Llama-2-13b-hf"],
@@ -570,6 +576,28 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "final_rms": True,
             "gated_mlp": True,
         }
+    elif official_model_name.startswith(
+        "CodeLlama-7b"
+    ): # same architecture CodeLlama and Llama-2
+        cfg_dict = {
+                    "d_model": 4096,
+                    "d_head": 4096 // 32,
+                    "n_heads": 32,
+                    "d_mlp": 11008,
+                    "n_layers": 32,
+                    "n_ctx": 4096,
+                    "eps": 1e-5,
+                    "d_vocab": 32016,
+                    "act_fn": "silu",
+                    "normalization_type": "RMS",
+                    "positional_embedding_type": "rotary",
+                    "rotary_dim": 4096 // 32,
+                    "final_rms": True,
+                    "gated_mlp": True,
+                    "rotary_base":  1000000
+                }
+        if "python" in official_model_name.lower():
+            cfg_dict["d_vocab"] = 32000
     elif official_model_name.startswith(
         ("llama-13b", "Llama-2-13b")
     ):  # same architecture for LLaMA and Llama-2


### PR DESCRIPTION
# Description

This PR adds support for CodeLlama-7b series. 

Related to issue https://github.com/neelnanda-io/TransformerLens/issues/468

The changes here are relatively minor since Llama2-7b is already available in this repo. These changes include:

1. Adjust `d_vocab` according to different versions.

2. Add a new `rotary_base` parameter in `HookedTransformerConfig`.

3. Apply the changes in `HookedTransformerConfig` to `Attention` module when calling `calculate_sin_cos_rotary`

I have tested these models locally. However it might be too time-consuming to load Llama and test the model in `test_hooked_transformer.py` so I did not write tests there.

Example test case:
```python
import torch
from transformer_lens import HookedTransformer
from transformers import AutoModelForCausalLM, AutoTokenizer

MODEL_NAME = "codellama/CodeLlama-7b-Python-hf"
model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, low_cpu_mem_usage=False)
model = model.eval()
tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
tl_model = HookedTransformer.from_pretrained_no_processing( # from_pretrained
    MODEL_NAME,
    hf_model=model,
    tokenizer=tokenizer,
    device="cpu",
    fold_ln=False,
    fold_value_biases=False,
    center_writing_weights=False,
    center_unembed=False,
)
tl_model = tl_model.eval()
prompts = ['def add (int a, int b):']
prompt_ids = [tokenizer.encode(prompt, return_tensors="pt") for prompt in prompts]
tl_logits = [tl_model(prompt_id) for prompt_id in tqdm.tqdm(prompt_ids)]
logits = [model(prompt_id).logits.detach().cpu() for prompt_id in (prompt_ids)]

assert torch.allclose(
        torch.softmax(tl_logits[0], dim=-1), torch.softmax(logits[0], dim=-1), atol=1e-5
    )
```

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

