### PR TITLE
Remove redundant MLP bias assignment

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1879,13 +1879,6 @@ def convert_nanogpt_weights(old_state_dict, cfg: HookedTransformerConfig):
                 f"{layer_key}.attn.c_proj.bias"
             ]
 
-            new_state_dict[f"blocks.{layer}.mlp.b_in"] = old_state_dict[
-                f"{layer_key}.mlp.c_fc.bias"
-            ].T
-            new_state_dict[f"blocks.{layer}.mlp.b_out"] = old_state_dict[
-                f"{layer_key}.mlp.c_proj.bias"
-            ].T
-
     return new_state_dict
 
 


### PR DESCRIPTION
# Description

I recently had a pull request merged to add a function for converting nanogpt models to transformer lens format. When using some of the code, I noticed that I had a redundant assignment for the bias values in the MLP.

Lines 1863-1868 assign the same values as lines 1882-1887. In addition, the second assignment had an unused .T transpose. The transpose is unused because the bias values are 1 dimensional.

Although this shouldn't change anything, I updated my Colab notebook contained here: https://colab.research.google.com/drive/1CqMRAezkc2vVJKPiKA3Q7ACdjgzH_y7K?authuser=0#scrollTo=dqaNKBD7V4Bk

And ensured that it still produced the same results as the run from my previous pull request: https://github.com/neelnanda-io/TransformerLens/pull/475

My apologies for the oversight.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
