### PR TITLE
Add `max_context_length` parameter to `HookedTransformer`

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1089,6 +1089,7 @@ class HookedTransformer(HookedRootModule):
         fold_value_biases: Optional[bool] = True,
         default_prepend_bos: Optional[bool] = True,
         default_padding_side: Optional[Literal["left", "right"]] = "right",
+        max_context_length: Optional[int] = 2048,
         dtype="float32",
         **from_pretrained_kwargs,
     ) -> "HookedTransformer":
@@ -1219,6 +1220,9 @@ class HookedTransformer(HookedRootModule):
                 other HuggingFace functions when compatible. For some models or arguments it doesn't
                 work, especially for models that are not internally loaded with HuggingFace's
                 from_pretrained (e.g. SoLU models).
+            max_context_length: The maximum context length to use for the model. Defaults to 2048. Can be set to
+                None to use the full context length of the model. Unless a larger context length is needed, it is
+                recommended to use the default value, as longer context lengths are highly memory intensive.
             dtype: What data type to load the model in (also sets the dtype of
                 the HuggingFace model). Set to bfloat16 or float16 if you get out of memory errors when loading
                 the model.
@@ -1260,6 +1264,7 @@ class HookedTransformer(HookedRootModule):
             device=device,
             n_devices=n_devices,
             default_prepend_bos=default_prepend_bos,
+            max_context_length=max_context_length,
             dtype=dtype,
             **from_pretrained_kwargs,
         )

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1331,6 +1331,7 @@ class HookedTransformer(HookedRootModule):
         dtype=torch.float32,
         default_prepend_bos=True,
         default_padding_side="right",
+        max_context_length=None,
         **from_pretrained_kwargs,
     ):
         """Wrapper for from_pretrained.
@@ -1348,6 +1349,7 @@ class HookedTransformer(HookedRootModule):
             dtype=dtype,
             default_prepend_bos=default_prepend_bos,
             default_padding_side=default_padding_side,
+            max_context_length=max_context_length,
             **from_pretrained_kwargs,
         )
 

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -975,8 +975,8 @@ def get_pretrained_model_config(
             so this empirically seems to give better results. To change the default behavior to False, pass in
             default_prepend_bos=False. Note that you can also locally override the default behavior by passing
             in prepend_bos=True/False when you call a method that processes the input string.
-        max_context_length (int, optional): The maximum value of `n_ctx` to use for the model.
-            If None, `n_ctx` is left uncapped. Defaults to None.
+        max_context_length (int, optional): The maximum value of :attr:`transformer_lens.HookedTransformer.n_ctx` to use
+            for the model. If None, `n_ctx` is left unchanged. Defaults to None.
         dtype (torch.dtype, optional): The dtype to load the TransformerLens model in.
         kwargs: Other optional arguments passed to HuggingFace's from_pretrained.
             Also given to other HuggingFace functions when compatible.


### PR DESCRIPTION
# Description

Adds a `max_context_length` parameter to `HookedTransformer.from_pretrained`,  `HookedTransformer.from_pretrained_no_processing` and `loading_from_pretrained.get_pretrained_model_config`, which caps the context length. By default, it is set to `2048` for `from_pretrained`, and `None` for the others (which leaves it uncapped).

Due to attention masks being stored ahead of time, memory usage grows with the square of context length, leading to some models (e.g. mistral) being unable to fit on consumer GPUs. 

Could potentially be breaking if the longer context was relied on.

Fixes #490 

Related to #479 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->