### PR TITLE
Cap Mistral's context length at 2k

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -815,7 +815,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "n_heads": 32,
             "d_mlp": 14336,
             "n_layers": 32,
-            "n_ctx": 2048,
+            "n_ctx": 2048, # Capped due to memory issues
             "d_vocab": 32000,
             "act_fn": "silu",
             "normalization_type": "RMS",

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -815,7 +815,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "n_heads": 32,
             "d_mlp": 14336,
             "n_layers": 32,
-            "n_ctx": 2048, # Capped due to memory issues
+            "n_ctx": 2048,  # Capped due to memory issues
             "d_vocab": 32000,
             "act_fn": "silu",
             "normalization_type": "RMS",

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -815,7 +815,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "n_heads": 32,
             "d_mlp": 14336,
             "n_layers": 32,
-            "n_ctx": 32768,
+            "n_ctx": 2048,
             "d_vocab": 32000,
             "act_fn": "silu",
             "normalization_type": "RMS",


### PR DESCRIPTION
# Description

Caps Mistral's context length at 2k, as its default length of 32k uses a very large amount of memory.

Discussed in #490 and #491

This change will not be needed after #493, and is just to allow for Mistral to be easily used in the short term while #493 is in review. 

Fixes #490 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->