### PR TITLE
Remove non-existing parameter from decompose_resid() documentation

### DIFF
--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -607,9 +607,6 @@ class ActivationCache:
                 layer==n_layers means to return all layer outputs incl in the final layer, layer==0
                 means just embed and pos_embed. The indices are taken such that this gives the
                 accumulated streams up to the input to layer l
-            incl_mid:
-                Whether to return resid_mid for all previous
-                layers.
             mlp_input:
                 Whether to include attn_out for the current
                 layer - essentially decomposing the residual stream that's input to the MLP input


### PR DESCRIPTION
# Description

The incl_mid parameter was in the documentation of decompose_resid() but it is not an actual parameter, probably copied over from accumulated_resid()

## Type of change

- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
