### PR TITLE
Add `@overload` to `FactoredMatrix.__{,r}matmul__`

### DIFF
--- a/transformer_lens/FactoredMatrix.py
+++ b/transformer_lens/FactoredMatrix.py
@@ -3,10 +3,11 @@
 Utilities for representing a matrix as a product of two matrices, and for efficient calculation of
 eigenvalues, norm and SVD.
 """
+
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, overload
 
 import torch
 from jaxtyping import Float
@@ -40,6 +41,23 @@ class FactoredMatrix:
         self.A = self.A.broadcast_to(self.shape[:-2] + (self.ldim, self.mdim))
         self.B = self.B.broadcast_to(self.shape[:-2] + (self.mdim, self.rdim))
 
+    @overload
+    def __matmul__(
+        self,
+        other: Union[
+            Float[torch.Tensor, "... rdim new_rdim"],
+            "FactoredMatrix",
+        ],
+    ) -> "FactoredMatrix":
+        ...
+
+    @overload
+    def __matmul__(
+        self,
+        other: Float[torch.Tensor, "rdim"],
+    ) -> Float[torch.Tensor, "... ldim"]:
+        ...
+
     def __matmul__(
         self,
         other: Union[
@@ -63,6 +81,23 @@ class FactoredMatrix:
                     return FactoredMatrix(self.AB, other)
         elif isinstance(other, FactoredMatrix):
             return (self @ other.A) @ other.B
+
+    @overload
+    def __rmatmul__(
+        self,
+        other: Union[
+            Float[torch.Tensor, "... new_rdim ldim"],
+            "FactoredMatrix",
+        ],
+    ) -> "FactoredMatrix":
+        ...
+
+    @overload
+    def __rmatmul__(
+        self,
+        other: Float[torch.Tensor, "ldim"],
+    ) -> Float[torch.Tensor, "... rdim"]:
+        ...
 
     def __rmatmul__(
         self,


### PR DESCRIPTION
# Description

This should `FactoredMatrix.__matmul__` to be used in `functools.reduce` without triggering type errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My changes generate no new warnings (does CI test this?)
- [ ] I have added tests that prove my fix is effective or that my feature works (is this necessary for a small change like this?)
- [ ] New and existing unit tests pass locally with my changes (have not tried this, I'm relying on CI, but also, this is just a typing annotation change)
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
