### PR TITLE
remove pytest dependency from utils.py

### DIFF
--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
 
 import einops
 import numpy as np
-import pytest
 import torch
 import torch.nn.functional as F
 import transformers
@@ -602,7 +601,6 @@ def remove_batch_dim(
 
 # Note: Docstring won't be tested with PyTest (it's ignored), as it thinks this is a regular unit
 # test (because it's name is prefixed `test_`).
-@pytest.mark.skip
 def test_prompt(
     prompt: str,
     answer: str,


### PR DESCRIPTION
# Description

This reverts part of a change from #463 which used pytest from utils.py without adding it as a runtime dependency. An alternative fix would be to change the dependencies.
 
Fixes #503

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
n/a - no new code to comment
- [ ] I have made corresponding changes to the documentation
n/a - no new code to document
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
 n/a - no new code to test
- [X] New and existing unit tests pass locally with my changes
428 passed, 2 skipped, 3 warnings, same as main
- [X] I have not rewritten tests relating to key interfaces which would affect backward compatibility
