### PR TITLE
Bugfix: remove redundant assert checks

### DIFF
--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -10,6 +10,7 @@ When reading these docs for the first time, we recommend reading the main :class
 class first, including the examples, and then skimming the available methods. You can then refer
 back to these docs depending on what you need to do.
 """
+
 from __future__ import annotations
 
 import logging
@@ -833,10 +834,8 @@ class ActivationCache:
             Tensor of the results.
         """
         if type(neuron_slice) is not Slice:
-            assert isinstance(neuron_slice, SliceInput)
             neuron_slice = Slice(neuron_slice)
         if type(pos_slice) is not Slice:
-            assert isinstance(pos_slice, SliceInput)
             pos_slice = Slice(pos_slice)
 
         neuron_acts = self[("post", layer, "mlp")]


### PR DESCRIPTION
# Description

The `isinstance` check fails on non-`Slice` input: `TypeError: Subscripted generics cannot be used with class and instance checks`.
Since the check seems redundant (same thing is repeated in `Slice` constructor), removing should be fine.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
