### PR TITLE
Llama 4bit v2 typing

### DIFF
--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -1022,10 +1022,8 @@ class Attention(AbstractAttention):
         if cfg.load_in_4bit:
             # 4-bit quantization convention
             nq = int((cfg.d_model * cfg.d_model) / 2)
-            self.W_Q = Params4bit(torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False)
             self.W_K = Params4bit(torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False)
             self.W_V = Params4bit(torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False)
-            self.W_O = Params4bit(torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False)
         else:
             self.W_K = nn.Parameter(
                 torch.empty(self.cfg.n_heads, self.cfg.d_model, self.cfg.d_head, dtype=cfg.dtype)


### PR DESCRIPTION
# Description

This change fixes typing problems that caused mypy issues for the 4bit-quanitized Llama PR, as discussed in #486. Concretely, it:
 - changes a use of `cfg.d_mlp` to `self.cfg.d_mlp`, as only the latter's type is known to mypy
 - changes the definition of `W_Q` and `W_O` in `AbstractAttention`, making them `bnb.Params4bit` if `cfg.load_in_4bit` is `True`, and `nn.Parameter` otherwise; in both cases, they're empty. It also removes the `W_Q` and `W_O` re-definitions in `Attention`.

The latter change is because `W_Q` and `W_O` were previously defined as `nn.Parameter` in `AbstractAttention` and then redefined (in `Attention`) as `bnb.Params4bit` if `cfg.load_in_4bit` was `True`. So, methods of `AbstractAttention` expected `nn.Parameter` instead of `bnb.Params4bit`. This change solves that problem, although one could also consider making `W_Q` and `W_O` into abstract attributes as with `W_K` and `W_V` .

Another option would be to just `assert`, where necessary, that relevant weights are `bnb.Params4bit` instead of `nn.Parameter`s, though I'm not sure this would solve the root issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility