### PR TITLE
Add support for Llama 3 (and Llama-2-70b-hf)

### DIFF
--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -961,7 +961,7 @@ class GroupedQueryAttention(AbstractAttention):
         attn_type: str = "global",
         layer_id: Union[int, None] = None,
     ):
-        """Grouped Query Attention Block - see https://arxiv.org/abs/2305.13245v2 for details.
+        """Grouped Query Attention Block - see https://arxiv.org/abs/2305.13245 for details.
         Similar to regular attention, W_Q, W_K, and W_V all have shape [head_index, d_model, d_head] and W_Q has shape [head_index, d_head, d_model].
         However, under the hood the key and value weights _W_K and _W_V are stored with shape [n_key_value_heads, d_model, d_head] and are expanded when the corresponding properties' getter is called.
         Similarly, during a forward pass, initially K and V are kept in shapes [batch, pos, n_key_value_heads, d_head] and will only be expanded to shapes [batch, pos, n_heads, d_head]

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -120,7 +120,6 @@ OFFICIAL_MODEL_NAMES = [
     "CodeLlama-7b-hf",
     "CodeLlama-7b-Python-hf",
     "CodeLlama-7b-Instruct-hf",
-    # TODO Llama-2-70b-hf (and Llama 3!) requires Grouped-Query Attention, see the paper https://arxiv.org/pdf/2307.09288.pdf
     "meta-llama/Meta-Llama-3-8B",
     "meta-llama/Meta-Llama-3-8B-Instruct",
     "meta-llama/Meta-Llama-3-70B",

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -120,7 +120,11 @@ OFFICIAL_MODEL_NAMES = [
     "CodeLlama-7b-hf",
     "CodeLlama-7b-Python-hf",
     "CodeLlama-7b-Instruct-hf",
-    # TODO Llama-2-70b-hf requires Grouped-Query Attention, see the paper https://arxiv.org/pdf/2307.09288.pdf
+    # TODO Llama-2-70b-hf (and Llama 3!) requires Grouped-Query Attention, see the paper https://arxiv.org/pdf/2307.09288.pdf
+    "meta-llama/Meta-Llama-3-8B",
+    "meta-llama/Meta-Llama-3-8B-Instruct",
+    "meta-llama/Meta-Llama-3-70B",
+    "meta-llama/Meta-Llama-3-70B-Instruct",
     "Baidicoot/Othello-GPT-Transformer-Lens",
     "bert-base-cased",
     "roneneldan/TinyStories-1M",
@@ -600,7 +604,7 @@ NON_HF_HOSTED_MODEL_NAMES = [
     "llama-30b-hf",
     "llama-65b-hf",
 ]
-"""Official model names for models that not hosted on HuggingFace."""
+"""Official model names for models not hosted on HuggingFace."""
 
 # Sets a default model alias, by convention the first one in the model alias table, else the official name if it has no aliases
 DEFAULT_MODEL_ALIASES = [
@@ -654,7 +658,10 @@ def convert_hf_model_config(model_name: str, **kwargs):
     # In case the user passed in an alias
     official_model_name = get_official_model_name(model_name)
     # Load HuggingFace model config
-    if "llama" in official_model_name.lower():
+    if (
+        "llama" in official_model_name.lower()
+        and "llama-3" not in official_model_name.lower()
+    ):
         architecture = "LlamaForCausalLM"
     elif "gemma" in official_model_name.lower():
         architecture = "GemmaForCausalLM"

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -657,7 +657,9 @@ def convert_hf_model_config(model_name: str, **kwargs):
     # In case the user passed in an alias
     official_model_name = get_official_model_name(model_name)
     # Load HuggingFace model config
-    if "gemma" in official_model_name.lower():
+    if official_model_name.lower() in NON_HF_HOSTED_MODEL_NAMES:
+        architecture = "LlamaForCausalLM"
+    elif "gemma" in official_model_name.lower():
         architecture = "GemmaForCausalLM"
     else:
         hf_config = AutoConfig.from_pretrained(official_model_name, **kwargs)

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -658,16 +658,12 @@ def convert_hf_model_config(model_name: str, **kwargs):
     # In case the user passed in an alias
     official_model_name = get_official_model_name(model_name)
     # Load HuggingFace model config
-    if (
-        "llama" in official_model_name.lower()
-        and "llama-3" not in official_model_name.lower()
-    ):
-        architecture = "LlamaForCausalLM"
-    elif "gemma" in official_model_name.lower():
+    if "gemma" in official_model_name.lower():
         architecture = "GemmaForCausalLM"
     else:
         hf_config = AutoConfig.from_pretrained(official_model_name, **kwargs)
         architecture = hf_config.architectures[0]
+
     if official_model_name.startswith(
         ("llama-7b", "meta-llama/Llama-2-7b")
     ):  # same architecture for LLaMA and Llama-2

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -657,7 +657,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
     # In case the user passed in an alias
     official_model_name = get_official_model_name(model_name)
     # Load HuggingFace model config
-    if official_model_name.lower() in NON_HF_HOSTED_MODEL_NAMES:
+    if "llama" in official_model_name.lower():
         architecture = "LlamaForCausalLM"
     elif "gemma" in official_model_name.lower():
         architecture = "GemmaForCausalLM"
@@ -772,6 +772,44 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "n_ctx": 4096,
             "eps": 1e-5,
             "d_vocab": 32000,
+            "act_fn": "silu",
+            "n_key_value_heads": 8,
+            "normalization_type": "RMS",
+            "positional_embedding_type": "rotary",
+            "rotary_adjacent_pairs": False,
+            "rotary_dim": 128,
+            "final_rms": True,
+            "gated_mlp": True,
+        }
+    elif "Meta-Llama-3-8B" in official_model_name:
+        cfg_dict = {
+            "d_model": 4096,
+            "d_head": 128,
+            "n_heads": 32,
+            "d_mlp": 14336,
+            "n_layers": 32,
+            "n_ctx": 8192,
+            "eps": 1e-5,
+            "d_vocab": 128256,
+            "act_fn": "silu",
+            "n_key_value_heads": 8,
+            "normalization_type": "RMS",
+            "positional_embedding_type": "rotary",
+            "rotary_adjacent_pairs": False,
+            "rotary_dim": 128,
+            "final_rms": True,
+            "gated_mlp": True,
+        }
+    elif "Meta-Llama-3-70B" in official_model_name:
+        cfg_dict = {
+            "d_model": 8192,
+            "d_head": 128,
+            "n_heads": 64,
+            "d_mlp": 28672,
+            "n_layers": 80,
+            "n_ctx": 8192,
+            "eps": 1e-5,
+            "d_vocab": 128256,
             "act_fn": "silu",
             "n_key_value_heads": 8,
             "normalization_type": "RMS",


### PR DESCRIPTION
# Description

This adds all four current Llama 3 models and enables Llama-2-70b-hf. No dependencies required for this change (but you must have been granted access on Hugging Face to download).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

I didn't add tests but I did write a sanity check:

`test.py`:
```
import transformer_lens

model = transformer_lens.HookedTransformer.from_pretrained(
    "meta-llama/Meta-Llama-3-8B-Instruct"
)

prompts = [
    "Hey how are you doing today?",
    "Two households, both alike in dignity\n(In fair Verona, where we lay our scene),",
    "The Times 03/Jan/2009",
]

for prompt in prompts:
    print(prompt)
    print(model.generate(prompt))
    tokens = model.to_tokens(prompt)
    logits, cache = model.run_with_cache(tokens, remove_batch_dim=True)
    print(type(logits))
    print(type(cache))
```

output:
```
(transformer-lens-py3.11) root@db2b43c33b4c:/workspace/TransformerLens# python3 test.py
/workspace/TransformerLens/.venv/lib/python3.11/site-packages/transformers/utils/hub.py:124: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
Downloading shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 161.14it/s]
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [03:18<00:00, 49.55s/it]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
WARNING:root:You are not using LayerNorm, so the writing weights can't be centered! Skipping
Loaded pretrained model meta-llama/Meta-Llama-3-8B-Instruct into HookedTransformer
Hey how are you doing today?
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:14<00:00,  1.46s/it]
Hey how are you doing today? I am having a pretty good day so far.
<class 'torch.Tensor'>
<class 'transformer_lens.ActivationCache.ActivationCache'>
Two households, both alike in dignity
(In fair Verona, where we lay our scene),
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:17<00:00,  1.74s/it]
Two households, both alike in dignity
(In fair Verona, where we lay our scene), - a grand and beautiful phrase. These words are
<class 'torch.Tensor'>
<class 'transformer_lens.ActivationCache.ActivationCache'>
The Times 03/Jan/2009
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:15<00:00,  1.53s/it]
The Times 03/Jan/2009
Breast cancer trial hears of ‘miracle
<class 'torch.Tensor'>
<class 'transformer_lens.ActivationCache.ActivationCache'>
```