### PR TITLE
Fixed device being set to cpu:0 instead of cpu

### DIFF
--- a/transformer_lens/utilities/devices.py
+++ b/transformer_lens/utilities/devices.py
@@ -38,6 +38,8 @@ def get_device_for_block_index(
     if device is None:
         device = cfg.device
     device = torch.device(device)
+    if device.type == "cpu":
+        return device
     device_index = (device.index or 0) + (index // layers_per_device)
     return torch.device(device.type, device_index)
 


### PR DESCRIPTION
# Description

When selecting a device for a module, TransformerLens will no longer use `cpu:0` instead of `cpu`. This was causing issue to the `nnsight` library (see https://github.com/ndif-team/nnsight/issues/121#issuecomment-2072435262)
Fixes # https://github.com/ndif-team/nnsight/issues/121#issuecomment-2072435262

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
Irrelevant for such a small fix

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->