### PR TITLE
Fix broken HookedSAETransformer demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ TransformerLens lets you load in 50+ different open source language models, and 
 activations of the model to you. You can cache any internal activation in the model, and add in
 functions to edit, remove or replace these activations as the model runs.
 
-The library also now supports mechanistic interpretability with SAEs (sparse autoencoders)! With [HookedSAETransformer](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/hooked-sae-transformer/demos/HookedSAETransformerDemo.ipynb), you can splice in SAEs during inference and cache + intervene on SAE activations. We recommend [SAELens](https://github.com/jbloomAus/SAELens) (built on top of TransformerLens) for training SAEs.
+The library also now supports mechanistic interpretability with SAEs (sparse autoencoders)! With [HookedSAETransformer](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/main/demos/Hooked_SAE_Transformer_Demo.ipynb), you can splice in SAEs during inference and cache + intervene on SAE activations. We recommend [SAELens](https://github.com/jbloomAus/SAELens) (built on top of TransformerLens) for training SAEs.
 
 ## Quick Start
 
@@ -51,7 +51,7 @@ logits, activations = model.run_with_cache("Hello World")
 * [Introduction to the Library and Mech
   Interp](https://arena-ch1-transformers.streamlit.app/[1.2]_Intro_to_Mech_Interp)
 * [Demo of Main TransformerLens Features](https://neelnanda.io/transformer-lens-demo)
-* [Demo of HookedSAETransformer Features](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/hooked-sae-transformer/demos/HookedSAETransformerDemo.ipynb)
+* [Demo of HookedSAETransformer Features](https://colab.research.google.com/github/neelnanda-io/TransformerLens/blob/main/demos/Hooked_SAE_Transformer_Demo.ipynb)
 
 ## Gallery
 


### PR DESCRIPTION
# Description

Looks like the HookedSAETransformer.ipynb demo was changed to Hooked_SAE_Transformer.ipynb, also I forgot to change the branch name. This PR fixes the demo links.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x] My changes generate no new warnings
- [ x] New and existing unit tests pass locally with my changes
- [ x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
