### PR TITLE
Fix Pos Slice Issue

### DIFF
--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -12,7 +12,7 @@ from typing import Callable, Dict, List, Literal, Optional, Sequence, Tuple, Uni
 import torch.nn as nn
 import torch.utils.hooks as hooks
 
-from transformer_lens.utils import Slice
+from transformer_lens.utils import Slice, SliceInput
 
 
 @dataclass
@@ -485,7 +485,7 @@ class HookedRootModule(nn.Module):
         device=None,
         remove_batch_dim: bool = False,
         cache: Optional[dict] = None,
-        pos_slice: Optional[Union[int, Slice]] = None,
+        pos_slice: Union[Slice, SliceInput] = None,
     ) -> Tuple[dict, list, list]:
         """Creates hooks to cache activations. Note: It does not add the hooks to the model.
 

--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -451,12 +451,7 @@ class HookedRootModule(nn.Module):
 
         """
 
-        if not isinstance(pos_slice, Slice):
-            if isinstance(
-                pos_slice, int
-            ):  # slicing with an int collapses the dimension so this stops the pos dimension from collapsing
-                pos_slice = [pos_slice]
-            pos_slice = Slice(pos_slice)
+        pos_slice = Slice.unwrap(pos_slice)
 
         cache_dict, fwd, bwd = self.get_caching_hooks(
             names_filter,
@@ -504,12 +499,7 @@ class HookedRootModule(nn.Module):
         if cache is None:
             cache = {}
 
-        if not isinstance(pos_slice, Slice):
-            if isinstance(
-                pos_slice, int
-            ):  # slicing with an int collapses the dimension so this stops the pos dimension from collapsing
-                pos_slice = [pos_slice]
-            pos_slice = Slice(pos_slice)
+        pos_slice = Slice.unwrap(pos_slice)
 
         if names_filter is None:
             names_filter = lambda name: True

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -11,7 +11,7 @@ import os
 import re
 import shutil
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast 
 
 import einops
 import numpy as np
@@ -521,6 +521,28 @@ class Slice:
         self,
     ) -> str:
         return f"Slice: {self.slice} Mode: {self.mode} "
+
+    @classmethod
+    def unwrap(
+        cls,
+        slice_input: Union["Slice", SliceInput],
+    ) -> "Slice":
+        """
+        Takes a Slice-like input and converts it into a Slice, if it is not already.
+
+        Args:
+            slice_input (Union[Slice, SliceInput]): The input to turn into a Slice.
+
+        Returns:
+            Slice: A Slice object.
+        """
+        if not isinstance(slice_input, Slice):
+            if isinstance(
+                slice_input, int
+            ):  # slicing with an int collapses the dimension so this stops the pos dimension from collapsing
+                slice_input = [slice_input]
+            slice_input = Slice(slice_input)
+        return slice_input
 
 
 def get_act_name(

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -11,7 +11,7 @@ import os
 import re
 import shutil
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast 
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import einops
 import numpy as np


### PR DESCRIPTION
# Description
There is an issue with `get_caching_hooks` where if `pos_slice` is set to `None` (the default behavior), using these hooks causes cause an assertion error (for details see #574). This is because the code actually expected `pos_slice` to be `Slice` object, even though it is typed as an `Optional[Slice]` . This change makes it so that the `pos_slice` object is converted to a `Slice` if it is not one already; it also updates the typing to indicate that `pos_slice` is a `Slice` or `SliceInput`, as in `run_with_cache`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility